### PR TITLE
Use MAPI v2 in policies and v4 collections

### DIFF
--- a/apim/policies/Policies.postman_collection.json
+++ b/apim/policies/Policies.postman_collection.json
@@ -1,8 +1,9 @@
 {
 	"info": {
-		"_postman_id": "f86b40a4-2929-420b-a974-219e15af109f",
+		"_postman_id": "2043d016-6e60-4e83-bfd3-5ddf22460727",
 		"name": "Policies",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "21844790"
 	},
 	"item": [
 		{
@@ -263,8 +264,8 @@
 											"script": {
 												"exec": [
 													"var jsonData = JSON.parse(responseBody);",
-													"postman.setEnvironmentVariable(\"api\", jsonData.id);",
-													"pm.collectionVariables.set(\"apiEntity\", jsonData)"
+													"postman.setEnvironmentVariable(\"apiId\", jsonData.id);",
+													"pm.collectionVariables.set(\"api\", jsonData)"
 												],
 												"type": "text/javascript"
 											}
@@ -290,7 +291,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"id\": \"json-2-json-v4-sync\",\n    \"name\": \"json-2-json-v4-sync\",\n    \"description\": \"json-2-json-v4-sync\",\n    \"apiVersion\": \"1.0.0\",\n    \"definitionVersion\": \"4.0.0\",\n    \"type\": \"proxy\",\n    \"listeners\": [\n        {\n            \"type\": \"http\",\n            \"paths\": [\n                {\n                    \"path\": \"/json2json/v4-sync\"\n                }\n            ],\n            \"entrypoints\": [\n                {\n                    \"type\": \"http-proxy\"\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default\",\n            \"type\": \"http-proxy\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default-endpoit\",\n                    \"type\": \"http-proxy\",\n                    \"configuration\": {\n                        \"target\": \"https://api.gravitee.io/echo\"\n                    }\n                }\n            ]\n        }\n    ],\n    \"flows\": [\n        {\n            \"name\": \"json-to-json\",\n            \"enabled\": true,\n            \"selectors\": [\n                {\n                    \"type\": \"http\",\n                    \"path\": \"/\",\n                    \"pathOperator\": \"STARTS_WITH\"\n                }\n            ],\n            \"request\": [\n                {\n                    \"name\": \"Json to Json\",\n                    \"description\": \"add an api properties in the request\",\n                    \"enabled\": true,\n                    \"policy\": \"json-to-json\",\n                    \"configuration\": {\n                        \"specification\": \"[{ \\\"operation\\\": \\\"default\\\", \\\"spec\\\": { \\\"static\\\": \\\"static-value\\\", \\\"my-prop\\\": \\\"{#api.properties['my-prop']}\\\"}}]\"\n                    }\n                }\n            ],\n            \"response\": [\n                {\n                    \"name\": \"Json to Json\",\n                    \"description\": \"rename response attributes\",\n                    \"enabled\": true,\n                    \"policy\": \"json-to-json\",\n                    \"configuration\": {\n                        \"scope\": \"RESPONSE\",\n                        \"specification\": \"[{\\\"operation\\\": \\\"shift\\\", \\\"spec\\\": {\\\"query_params\\\": \\\"queryParams\\\", \\\"body\\\": \\\"requestBody\\\", \\\"headers\\\": \\\"headers\\\", \\\"method\\\": \\\"method\\\"}}]\"\n                    }\n                }\n            ],\n            \"subscribe\": [],\n            \"publish\": []\n        }\n    ]\n}",
+											"raw": "{\n    \"id\": \"json-2-json-v4-sync\",\n    \"name\": \"json-2-json-v4-sync\",\n    \"description\": \"json-2-json-v4-sync\",\n    \"apiVersion\": \"1.0.0\",\n    \"definitionVersion\": \"V4\",\n    \"type\": \"PROXY\",\n    \"listeners\": [\n        {\n            \"type\": \"HTTP\",\n            \"paths\": [\n                {\n                    \"path\": \"/json2json/v4-sync\"\n                }\n            ],\n            \"entrypoints\": [\n                {\n                    \"type\": \"http-proxy\"\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default\",\n            \"type\": \"http-proxy\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default-endpoit\",\n                    \"type\": \"http-proxy\",\n                    \"configuration\": {\n                        \"target\": \"https://api.gravitee.io/echo\"\n                    }\n                }\n            ]\n        }\n    ],\n    \"flows\": [\n        {\n            \"name\": \"json-to-json\",\n            \"enabled\": true,\n            \"selectors\": [\n                {\n                    \"type\": \"HTTP\",\n                    \"path\": \"/\",\n                    \"pathOperator\": \"STARTS_WITH\"\n                }\n            ],\n            \"request\": [\n                {\n                    \"name\": \"Json to Json\",\n                    \"description\": \"add an api properties in the request\",\n                    \"enabled\": true,\n                    \"policy\": \"json-to-json\",\n                    \"configuration\": {\n                        \"specification\": \"[{ \\\"operation\\\": \\\"default\\\", \\\"spec\\\": { \\\"static\\\": \\\"static-value\\\", \\\"my-prop\\\": \\\"{#api.properties['my-prop']}\\\"}}]\"\n                    }\n                }\n            ],\n            \"response\": [\n                {\n                    \"name\": \"Json to Json\",\n                    \"description\": \"rename response attributes\",\n                    \"enabled\": true,\n                    \"policy\": \"json-to-json\",\n                    \"configuration\": {\n                        \"scope\": \"RESPONSE\",\n                        \"specification\": \"[{\\\"operation\\\": \\\"shift\\\", \\\"spec\\\": {\\\"query_params\\\": \\\"queryParams\\\", \\\"body\\\": \\\"requestBody\\\", \\\"headers\\\": \\\"headers\\\", \\\"method\\\": \\\"method\\\"}}]\"\n                    }\n                }\n            ],\n            \"subscribe\": [],\n            \"publish\": []\n        }\n    ]\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -298,17 +299,15 @@
 											}
 										},
 										"url": {
-											"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/",
+											"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/",
 											"host": [
 												"{{management_host}}"
 											],
 											"path": [
 												"management",
-												"organizations",
-												"DEFAULT",
+												"v2",
 												"environments",
 												"DEFAULT",
-												"v4",
 												"apis",
 												""
 											]
@@ -332,16 +331,16 @@
 											"listen": "prerequest",
 											"script": {
 												"exec": [
-													"var apiEntity = pm.collectionVariables.get(\"apiEntity\")",
+													"var api = pm.collectionVariables.get(\"api\")",
 													"",
 													"var body= {",
-													"    \"id\": `${apiEntity.id}`,",
-													"    \"name\": `${apiEntity.name}`,",
-													"    \"description\": `${apiEntity.description}`,",
-													"    \"apiVersion\": `${apiEntity.apiVersion}`,",
-													"    \"definitionVersion\": `${apiEntity.definitionVersion}`,",
-													"    \"type\": `${apiEntity.type}`,",
-													"    \"visibility\": `${apiEntity.visibility}`,",
+													"    \"id\": `${api.id}`,",
+													"    \"name\": `${api.name}`,",
+													"    \"description\": `${api.description}`,",
+													"    \"apiVersion\": `${api.apiVersion}`,",
+													"    \"definitionVersion\": `${api.definitionVersion}`,",
+													"    \"type\": `${api.type}`,",
+													"    \"visibility\": `${api.visibility}`,",
 													"    \"analytics\": {},",
 													"    \"properties\": [",
 													"        {",
@@ -350,9 +349,9 @@
 													"            \"encrypted\": false",
 													"        }",
 													"    ],",
-													"    \"listeners\": apiEntity.listeners,",
-													"    \"endpointGroups\": apiEntity.endpointGroups,",
-													"    \"flows\": apiEntity.flows",
+													"    \"listeners\": api.listeners,",
+													"    \"endpointGroups\": api.endpointGroups,",
+													"    \"flows\": api.flows",
 													"}",
 													"",
 													"pm.collectionVariables.set(\"v4_sync_api_add_properties\", JSON.stringify(body))"
@@ -389,19 +388,17 @@
 											}
 										},
 										"url": {
-											"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}",
+											"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}",
 											"host": [
 												"{{management_host}}"
 											],
 											"path": [
 												"management",
-												"organizations",
-												"DEFAULT",
+												"v2",
 												"environments",
 												"DEFAULT",
-												"v4",
 												"apis",
-												"{{api}}"
+												"{{apiId}}"
 											]
 										}
 									},
@@ -415,7 +412,7 @@
 											"script": {
 												"exec": [
 													"var jsonData = JSON.parse(responseBody);",
-													"postman.setEnvironmentVariable(\"plan\", jsonData.id);"
+													"postman.setEnvironmentVariable(\"planId\", jsonData.id);"
 												],
 												"type": "text/javascript"
 											}
@@ -441,7 +438,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"name\":\"Keyless\",\n    \"description\":\"Keyless\",\n    \"characteristics\":[],\n    \"security\": {\n        \"type\": \"key-less\"\n    }\n}",
+											"raw": "{\n    \"definitionVersion\": \"V4\",\n    \"name\":\"Keyless\",\n    \"description\":\"Keyless\",\n    \"characteristics\":[],\n    \"security\": {\n        \"type\": \"KEY_LESS\"\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -449,19 +446,17 @@
 											}
 										},
 										"url": {
-											"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans",
+											"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans",
 											"host": [
 												"{{management_host}}"
 											],
 											"path": [
 												"management",
-												"organizations",
-												"DEFAULT",
+												"v2",
 												"environments",
 												"DEFAULT",
-												"v4",
 												"apis",
-												"{{api}}",
+												"{{apiId}}",
 												"plans"
 											]
 										}
@@ -500,21 +495,19 @@
 										"method": "POST",
 										"header": [],
 										"url": {
-											"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans/{{plan}}/_publish",
+											"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans/{{planId}}/_publish",
 											"host": [
 												"{{management_host}}"
 											],
 											"path": [
 												"management",
-												"organizations",
-												"DEFAULT",
+												"v2",
 												"environments",
 												"DEFAULT",
-												"v4",
 												"apis",
-												"{{api}}",
+												"{{apiId}}",
 												"plans",
-												"{{plan}}",
+												"{{planId}}",
 												"_publish"
 											]
 										}
@@ -562,26 +555,18 @@
 											}
 										},
 										"url": {
-											"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/?action=start",
+											"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/_start",
 											"host": [
 												"{{management_host}}"
 											],
 											"path": [
 												"management",
-												"organizations",
-												"DEFAULT",
+												"v2",
 												"environments",
 												"DEFAULT",
-												"v4",
 												"apis",
-												"{{api}}",
-												""
-											],
-											"query": [
-												{
-													"key": "action",
-													"value": "start"
-												}
+												"{{apiId}}",
+												"_start"
 											]
 										}
 									},
@@ -600,8 +585,8 @@
 											"script": {
 												"exec": [
 													"var jsonData = JSON.parse(responseBody);",
-													"postman.setEnvironmentVariable(\"api\", jsonData.id);",
-													"pm.collectionVariables.set(\"apiEntity\", jsonData)"
+													"postman.setEnvironmentVariable(\"apiId\", jsonData.id);",
+													"pm.collectionVariables.set(\"api\", jsonData)"
 												],
 												"type": "text/javascript"
 											}
@@ -627,7 +612,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"id\": \"json-2-json-v4-async\",\n    \"name\": \"json-2-json-v4-async\",\n    \"description\": \"json-2-json-v4-async\",\n    \"apiVersion\": \"1.0.0\",\n    \"definitionVersion\": \"4.0.0\",\n    \"type\": \"message\",\n    \"listeners\": [\n        {\n            \"type\": \"http\",\n            \"paths\": [\n                {\n                    \"path\": \"/json2json/v4-async\"\n                }\n            ],\n            \"entrypoints\": [\n                {\n                    \"type\": \"sse\",\n                    \"configuration\": {\n                        \"heartbeatIntervalInMs\": 5000,\n                        \"metadataAsComment\": false,\n                        \"headersAsComment\": false\n                    }\n                },\n                {\n                    \"type\": \"http-post\",\n                    \"configuration\": {\n                        \"requestHeadersToMessage\": false\n                    }\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default\",\n            \"type\": \"mock\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default-endpoint\",\n                    \"type\": \"mock\",\n                    \"weight\": 1,\n                    \"inheritConfiguration\": false,\n                    \"configuration\": {\n                        \"messageInterval\": 1000,\n                        \"messageContent\": \"{ \\\"_id\\\": \\\"57762dc6ab7d620000000001\\\", \\\"name\\\": \\\"name\\\", \\\"__v\\\": 0 }\"\n                    }\n                }\n            ]\n        }\n    ],\n    \"flows\": [\n        {\n            \"name\": \"json-to-json\",\n            \"enabled\": true,\n            \"selectors\": [\n                {\n                    \"type\": \"channel\",\n                    \"operation\": [\"PUBLISH\", \"SUBSCRIBE\"],\n                    \"channel\": \"/\",\n                    \"channel-operator\": \"STARTS_WITH\"\n                }\n            ],\n            \"request\": [],\n            \"response\": [],\n            \"subscribe\": [\n                 {\n                    \"name\": \"Json to Json\",\n                    \"description\": \"rename _id and drop __v\",\n                    \"enabled\": true,\n                    \"policy\": \"json-to-json\",\n                    \"configuration\": {\n                        \"specification\": \"[{\\\"operation\\\": \\\"shift\\\",\\\"spec\\\": {\\\"_id\\\": \\\"id\\\",\\\"*\\\": {\\\"$\\\": \\\"&1\\\"}}},{\\\"operation\\\": \\\"remove\\\",\\\"spec\\\": {\\\"__v\\\": \\\"\\\"}}]\"\n                    }\n                }\n            ],\n            \"publish\": [\n                 {\n                    \"name\": \"Json to Json\",\n                    \"description\": \"add an api properties in the message\",\n                    \"enabled\": true,\n                    \"policy\": \"json-to-json\",\n                    \"configuration\": {\n                        \"specification\": \"[{ \\\"operation\\\": \\\"default\\\", \\\"spec\\\": { \\\"static\\\": \\\"static-value\\\", \\\"my-prop\\\": \\\"{#api.properties['my-prop']}\\\"}}]\"\n                    }\n                }\n            ]\n        }\n    ]\n}",
+											"raw": "{\n    \"id\": \"json-2-json-v4-async\",\n    \"name\": \"json-2-json-v4-async\",\n    \"description\": \"json-2-json-v4-async\",\n    \"apiVersion\": \"1.0.0\",\n    \"definitionVersion\": \"V4\",\n    \"type\": \"MESSAGE\",\n    \"listeners\": [\n        {\n            \"type\": \"HTTP\",\n            \"paths\": [\n                {\n                    \"path\": \"/json2json/v4-async\"\n                }\n            ],\n            \"entrypoints\": [\n                {\n                    \"type\": \"sse\",\n                    \"configuration\": {\n                        \"heartbeatIntervalInMs\": 5000,\n                        \"metadataAsComment\": false,\n                        \"headersAsComment\": false\n                    }\n                },\n                {\n                    \"type\": \"http-post\",\n                    \"configuration\": {\n                        \"requestHeadersToMessage\": false\n                    }\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default\",\n            \"type\": \"mock\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default-endpoint\",\n                    \"type\": \"mock\",\n                    \"weight\": 1,\n                    \"inheritConfiguration\": false,\n                    \"configuration\": {\n                        \"messageInterval\": 1000,\n                        \"messageContent\": \"{ \\\"_id\\\": \\\"57762dc6ab7d620000000001\\\", \\\"name\\\": \\\"name\\\", \\\"__v\\\": 0 }\"\n                    }\n                }\n            ]\n        }\n    ],\n    \"flows\": [\n        {\n            \"name\": \"json-to-json\",\n            \"enabled\": true,\n            \"selectors\": [\n                {\n                    \"type\": \"CHANNEL\",\n                    \"operation\": [\"PUBLISH\", \"SUBSCRIBE\"],\n                    \"channel\": \"/\",\n                    \"channelOperator\": \"STARTS_WITH\"\n                }\n            ],\n            \"request\": [],\n            \"response\": [],\n            \"subscribe\": [\n                 {\n                    \"name\": \"Json to Json\",\n                    \"description\": \"rename _id and drop __v\",\n                    \"enabled\": true,\n                    \"policy\": \"json-to-json\",\n                    \"configuration\": {\n                        \"specification\": \"[{\\\"operation\\\": \\\"shift\\\",\\\"spec\\\": {\\\"_id\\\": \\\"id\\\",\\\"*\\\": {\\\"$\\\": \\\"&1\\\"}}},{\\\"operation\\\": \\\"remove\\\",\\\"spec\\\": {\\\"__v\\\": \\\"\\\"}}]\"\n                    }\n                }\n            ],\n            \"publish\": [\n                 {\n                    \"name\": \"Json to Json\",\n                    \"description\": \"add an api properties in the message\",\n                    \"enabled\": true,\n                    \"policy\": \"json-to-json\",\n                    \"configuration\": {\n                        \"specification\": \"[{ \\\"operation\\\": \\\"default\\\", \\\"spec\\\": { \\\"static\\\": \\\"static-value\\\", \\\"my-prop\\\": \\\"{#api.properties['my-prop']}\\\"}}]\"\n                    }\n                }\n            ]\n        }\n    ]\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -635,17 +620,15 @@
 											}
 										},
 										"url": {
-											"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/",
+											"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/",
 											"host": [
 												"{{management_host}}"
 											],
 											"path": [
 												"management",
-												"organizations",
-												"DEFAULT",
+												"v2",
 												"environments",
 												"DEFAULT",
-												"v4",
 												"apis",
 												""
 											]
@@ -669,16 +652,16 @@
 											"listen": "prerequest",
 											"script": {
 												"exec": [
-													"var apiEntity = pm.collectionVariables.get(\"apiEntity\")",
+													"var api = pm.collectionVariables.get(\"api\")",
 													"",
 													"var body= {",
-													"    \"id\": `${apiEntity.id}`,",
-													"    \"name\": `${apiEntity.name}`,",
-													"    \"description\": `${apiEntity.description}`,",
-													"    \"apiVersion\": `${apiEntity.apiVersion}`,",
-													"    \"definitionVersion\": `${apiEntity.definitionVersion}`,",
-													"    \"type\": `${apiEntity.type}`,",
-													"    \"visibility\": `${apiEntity.visibility}`,",
+													"    \"id\": `${api.id}`,",
+													"    \"name\": `${api.name}`,",
+													"    \"description\": `${api.description}`,",
+													"    \"apiVersion\": `${api.apiVersion}`,",
+													"    \"definitionVersion\": `${api.definitionVersion}`,",
+													"    \"type\": `${api.type}`,",
+													"    \"visibility\": `${api.visibility}`,",
 													"    \"analytics\": {},",
 													"    \"properties\": [",
 													"        {",
@@ -687,9 +670,9 @@
 													"            \"encrypted\": false",
 													"        }",
 													"    ],",
-													"    \"listeners\": apiEntity.listeners,",
-													"    \"endpointGroups\": apiEntity.endpointGroups,",
-													"    \"flows\": apiEntity.flows",
+													"    \"listeners\": api.listeners,",
+													"    \"endpointGroups\": api.endpointGroups,",
+													"    \"flows\": api.flows",
 													"}",
 													"",
 													"pm.collectionVariables.set(\"v4_sync_api_add_properties\", JSON.stringify(body))"
@@ -726,19 +709,17 @@
 											}
 										},
 										"url": {
-											"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}",
+											"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}",
 											"host": [
 												"{{management_host}}"
 											],
 											"path": [
 												"management",
-												"organizations",
-												"DEFAULT",
+												"v2",
 												"environments",
 												"DEFAULT",
-												"v4",
 												"apis",
-												"{{api}}"
+												"{{apiId}}"
 											]
 										}
 									},
@@ -752,7 +733,7 @@
 											"script": {
 												"exec": [
 													"var jsonData = JSON.parse(responseBody);",
-													"postman.setEnvironmentVariable(\"plan\", jsonData.id);"
+													"postman.setEnvironmentVariable(\"planId\", jsonData.id);"
 												],
 												"type": "text/javascript"
 											}
@@ -778,7 +759,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"name\":\"Keyless\",\n    \"description\":\"Keyless\",\n    \"characteristics\":[],\n    \"security\": {\n        \"type\": \"key-less\"\n    }\n}",
+											"raw": "{\n    \"definitionVersion\": \"V4\",\n    \"name\":\"Keyless\",\n    \"description\":\"Keyless\",\n    \"characteristics\":[],\n    \"security\": {\n        \"type\": \"KEY_LESS\"\n    }\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -786,19 +767,17 @@
 											}
 										},
 										"url": {
-											"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans",
+											"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans",
 											"host": [
 												"{{management_host}}"
 											],
 											"path": [
 												"management",
-												"organizations",
-												"DEFAULT",
+												"v2",
 												"environments",
 												"DEFAULT",
-												"v4",
 												"apis",
-												"{{api}}",
+												"{{apiId}}",
 												"plans"
 											]
 										}
@@ -837,21 +816,19 @@
 										"method": "POST",
 										"header": [],
 										"url": {
-											"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans/{{plan}}/_publish",
+											"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans/{{planId}}/_publish",
 											"host": [
 												"{{management_host}}"
 											],
 											"path": [
 												"management",
-												"organizations",
-												"DEFAULT",
+												"v2",
 												"environments",
 												"DEFAULT",
-												"v4",
 												"apis",
-												"{{api}}",
+												"{{apiId}}",
 												"plans",
-												"{{plan}}",
+												"{{planId}}",
 												"_publish"
 											]
 										}
@@ -899,26 +876,18 @@
 											}
 										},
 										"url": {
-											"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/?action=start",
+											"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/_start",
 											"host": [
 												"{{management_host}}"
 											],
 											"path": [
 												"management",
-												"organizations",
-												"DEFAULT",
+												"v2",
 												"environments",
 												"DEFAULT",
-												"v4",
 												"apis",
-												"{{api}}",
-												""
-											],
-											"query": [
-												{
-													"key": "action",
-													"value": "start"
-												}
+												"{{apiId}}",
+												"_start"
 											]
 										}
 									},
@@ -938,6 +907,10 @@
 		},
 		{
 			"key": "v4_sync_api_add_properties",
+			"value": ""
+		},
+		{
+			"key": "api",
 			"value": ""
 		}
 	]

--- a/apim/v4/V4_API_Environment.postman_environment.json
+++ b/apim/v4/V4_API_Environment.postman_environment.json
@@ -1,5 +1,5 @@
 {
-	"id": "f042467b-0d95-42e5-8d36-7609245372ef",
+	"id": "1bf6b4d1-f74d-4506-9634-0398666ca2e8",
 	"name": "V4 APIM Environment",
 	"values": [
 		{
@@ -11,6 +11,12 @@
 		{
 			"key": "gateway_host",
 			"value": "http://localhost:8082",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "portal_api_host",
+			"value": "http://localhost:8083",
 			"type": "default",
 			"enabled": true
 		},
@@ -49,9 +55,21 @@
 			"value": "",
 			"type": "any",
 			"enabled": true
+		},
+		{
+			"key": "apiId",
+			"value": "",
+			"type": "any",
+			"enabled": true
+		},
+		{
+			"key": "planId",
+			"value": "",
+			"type": "any",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2022-10-11T16:10:47.716Z",
-	"_postman_exported_using": "Postman/9.24.2"
+	"_postman_exported_at": "2023-06-18T21:21:20.859Z",
+	"_postman_exported_using": "Postman/10.14.9"
 }

--- a/apim/v4/V4_API_Management.postman_collection.json
+++ b/apim/v4/V4_API_Management.postman_collection.json
@@ -1,8 +1,9 @@
 {
 	"info": {
-		"_postman_id": "e8111a0c-77e9-4ea6-a84d-0e6310ffc0f9",
+		"_postman_id": "989cc853-f172-4308-89ef-cd08ae8005e6",
 		"name": "V4 API Management",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "21844790"
 	},
 	"item": [
 		{
@@ -52,7 +53,7 @@
 									"script": {
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
-											"postman.setEnvironmentVariable(\"api\", jsonData.id);"
+											"postman.setEnvironmentVariable(\"apiId\", jsonData.id);"
 										],
 										"type": "text/javascript"
 									}
@@ -85,7 +86,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"name\": \"Data Ingestion to Kafka\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"4.0.0\",\n    \"type\": \"message\",\n    \"description\": \"Data Ingestion to Kafka\",\n    \"listeners\": [\n        {\n            \"type\": \"http\",\n            \"paths\": [\n                {\n                    \"path\": \"/data/ingestion/kafka\"\n                }\n            ],\n            \"entrypoints\": [\n                {\n                    \"type\": \"http-post\",\n                    \"configuration\": {\n                        \"requestHeadersToMessage\": false\n                    }\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"kafka\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"kafka\",\n                    \"weight\": 1,\n                    \"inheritConfiguration\": false,\n                    \"configuration\": {\n                        \"bootstrapServers\": \"kafka:9092\"\n                        \n                    },\n                    \"sharedConfigurationOverride\": {\n                        \"producer\": {\n                            \"enabled\": true,\n                            \"topics\" : [\"demo\"]\n                        }\n                    }\n                }\n            ]\n        }\n    ],\n    \"flows\": [\n        {\n            \"name\": \"\",\n            \"selectors\": [],\n            \"request\": [],\n            \"response\": [],\n            \"subscribe\": [],\n            \"publish\": [],\n            \"enabled\": true\n        }\n    ]\n}",
+									"raw": "{\n    \"name\": \"Data Ingestion to Kafka\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"V4\",\n    \"type\": \"MESSAGE\",\n    \"description\": \"Data Ingestion to Kafka\",\n    \"listeners\": [\n        {\n            \"type\": \"HTTP\",\n            \"paths\": [\n                {\n                    \"path\": \"/data/ingestion/kafka\"\n                }\n            ],\n            \"entrypoints\": [\n                {\n                    \"type\": \"http-post\",\n                    \"configuration\": {\n                        \"requestHeadersToMessage\": false\n                    }\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"kafka\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"kafka\",\n                    \"weight\": 1,\n                    \"inheritConfiguration\": false,\n                    \"configuration\": {\n                        \"bootstrapServers\": \"kafka:9092\"\n                        \n                    },\n                    \"sharedConfigurationOverride\": {\n                        \"producer\": {\n                            \"enabled\": true,\n                            \"topics\" : [\"demo\"]\n                        }\n                    }\n                }\n            ]\n        }\n    ],\n    \"flows\": [\n        {\n            \"name\": \"\",\n            \"selectors\": [],\n            \"request\": [],\n            \"response\": [],\n            \"subscribe\": [],\n            \"publish\": [],\n            \"enabled\": true\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -93,17 +94,15 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
 										""
 									]
@@ -119,7 +118,7 @@
 									"script": {
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
-											"postman.setEnvironmentVariable(\"plan\", jsonData.id);"
+											"postman.setEnvironmentVariable(\"planId\", jsonData.id);"
 										],
 										"type": "text/javascript"
 									}
@@ -145,7 +144,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"name\":\"Keyless\",\n    \"description\":\"Keyless\",\n    \"characteristics\":[],\n    \"security\": {\n        \"type\": \"key-less\"\n    },\n    \"mode\": \"STANDARD\"\n}",
+									"raw": "{\n    \"definitionVersion\":\"V4\",\n    \"name\":\"Keyless\",\n    \"description\":\"Keyless\",\n    \"characteristics\":[],\n    \"security\": {\n        \"type\": \"KEY_LESS\"\n    },\n    \"mode\": \"STANDARD\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -153,19 +152,17 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"plans"
 									]
 								}
@@ -193,21 +190,19 @@
 								"method": "POST",
 								"header": [],
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans/{{plan}}/_publish",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans/{{planId}}/_publish",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"plans",
-										"{{plan}}",
+										"{{planId}}",
 										"_publish"
 									]
 								}
@@ -235,26 +230,18 @@
 								"method": "POST",
 								"header": [],
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/?action=start",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/_start",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
-										""
-									],
-									"query": [
-										{
-											"key": "action",
-											"value": "start"
-										}
+										"{{apiId}}",
+										"_start"
 									]
 								}
 							},
@@ -306,7 +293,7 @@
 									"script": {
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
-											"postman.setEnvironmentVariable(\"api\", jsonData.id);"
+											"postman.setEnvironmentVariable(\"apiId\", jsonData.id);"
 										],
 										"type": "text/javascript"
 									}
@@ -339,7 +326,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"name\": \"Data Ingestion to MQTT 5.x\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"4.0.0\",\n    \"type\": \"message\",\n    \"description\": \"Data Ingestion to MQTT 5.x\",\n    \"listeners\": [\n        {\n            \"type\": \"http\",\n            \"paths\": [\n                {\n                    \"path\": \"/data/ingestion/mqtt5\"\n                }\n            ],\n            \"entrypoints\": [\n                {\n                    \"type\": \"http-post\",\n                    \"configuration\": {\n                        \"requestHeadersToMessage\": false\n                    }\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"mqtt5\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"mqtt5\",\n                    \"weight\": 1,\n                    \"inheritConfiguration\": false,\n                    \"configuration\": {\n                        \"serverHost\": \"hivemq\",\n                        \"serverPort\": 1883\n                    },\n                    \"sharedConfigurationOverride\": {\n                        \"producer\": {\n                            \"enabled\": true,\n                            \"topic\": \"demo\",\n                            \"retained\": false\n                        }\n                    }\n                }\n            ]\n        }\n    ]\n}",
+									"raw": "{\n    \"name\": \"Data Ingestion to MQTT 5.x\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"V4\",\n    \"type\": \"MESSAGE\",\n    \"description\": \"Data Ingestion to MQTT 5.x\",\n    \"listeners\": [\n        {\n            \"type\": \"HTTP\",\n            \"paths\": [\n                {\n                    \"path\": \"/data/ingestion/mqtt5\"\n                }\n            ],\n            \"entrypoints\": [\n                {\n                    \"type\": \"http-post\",\n                    \"configuration\": {\n                        \"requestHeadersToMessage\": false\n                    }\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"mqtt5\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"mqtt5\",\n                    \"weight\": 1,\n                    \"inheritConfiguration\": false,\n                    \"configuration\": {\n                        \"serverHost\": \"hivemq\",\n                        \"serverPort\": 1883\n                    },\n                    \"sharedConfigurationOverride\": {\n                        \"producer\": {\n                            \"enabled\": true,\n                            \"topic\": \"demo\",\n                            \"retained\": false\n                        }\n                    }\n                }\n            ]\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -347,17 +334,15 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
 										""
 									]
@@ -373,7 +358,7 @@
 									"script": {
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
-											"postman.setEnvironmentVariable(\"plan\", jsonData.id);"
+											"postman.setEnvironmentVariable(\"planId\", jsonData.id);"
 										],
 										"type": "text/javascript"
 									}
@@ -399,7 +384,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"name\":\"Keyless\",\n    \"description\":\"Keyless\",\n    \"characteristics\":[],\n    \"security\": {\n        \"type\": \"key-less\"\n    },\n    \"mode\": \"STANDARD\"\n}",
+									"raw": "{\n    \"definitionVersion\":\"V4\",\n    \"name\":\"Keyless\",\n    \"description\":\"Keyless\",\n    \"characteristics\":[],\n    \"security\": {\n        \"type\": \"KEY_LESS\"\n    },\n    \"mode\": \"STANDARD\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -407,19 +392,17 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"plans"
 									]
 								}
@@ -447,21 +430,19 @@
 								"method": "POST",
 								"header": [],
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans/{{plan}}/_publish",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans/{{planId}}/_publish",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"plans",
-										"{{plan}}",
+										"{{planId}}",
 										"_publish"
 									]
 								}
@@ -489,26 +470,18 @@
 								"method": "POST",
 								"header": [],
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/?action=start",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/_start",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
-										""
-									],
-									"query": [
-										{
-											"key": "action",
-											"value": "start"
-										}
+										"{{apiId}}",
+										"_start"
 									]
 								}
 							},
@@ -560,7 +533,7 @@
 									"script": {
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
-											"postman.setEnvironmentVariable(\"api\", jsonData.id);"
+											"postman.setEnvironmentVariable(\"apiId\", jsonData.id);"
 										],
 										"type": "text/javascript"
 									}
@@ -593,7 +566,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"name\": \"Data Ingestion to MQTT 5.x with Authentication\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"4.0.0\",\n    \"type\": \"message\",\n    \"description\": \"Data Ingestion to MQTT 5.x with Authentication\",\n    \"listeners\": [\n        {\n            \"type\": \"http\",\n            \"paths\": [\n                {\n                    \"path\": \"/data/ingestion/mqtt5-auth\"\n                }\n            ],\n            \"entrypoints\": [\n                {\n                    \"type\": \"http-post\",\n                    \"configuration\": {\n                        \"requestHeadersToMessage\": false\n                    }\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"mqtt5\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"mqtt5\",\n                    \"weight\": 1,\n                    \"inheritConfiguration\": false,\n                    \"configuration\": {\n                        \"serverHost\": \"hivemq\",\n                        \"serverPort\": 1883\n                    },\n                    \"sharedConfigurationOverride\": {\n                        \"security\": {\n                            \"auth\": {\n                                \"username\": \"admin-user\",\n                                \"password\": \"admin-password\"\n                            }\n                        },\n                        \"producer\": {\n                            \"enabled\": true,\n                            \"topic\": \"demo\",\n                            \"retained\": false\n                        }\n                    }\n                }\n            ]\n        }\n    ]\n}",
+									"raw": "{\n    \"name\": \"Data Ingestion to MQTT 5.x with Authentication\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"V4\",\n    \"type\": \"MESSAGE\",\n    \"description\": \"Data Ingestion to MQTT 5.x with Authentication\",\n    \"listeners\": [\n        {\n            \"type\": \"HTTP\",\n            \"paths\": [\n                {\n                    \"path\": \"/data/ingestion/mqtt5-auth\"\n                }\n            ],\n            \"entrypoints\": [\n                {\n                    \"type\": \"http-post\",\n                    \"configuration\": {\n                        \"requestHeadersToMessage\": false\n                    }\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"mqtt5\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"mqtt5\",\n                    \"weight\": 1,\n                    \"inheritConfiguration\": false,\n                    \"configuration\": {\n                        \"serverHost\": \"hivemq\",\n                        \"serverPort\": 1883\n                    },\n                    \"sharedConfigurationOverride\": {\n                        \"security\": {\n                            \"auth\": {\n                                \"username\": \"admin-user\",\n                                \"password\": \"admin-password\"\n                            }\n                        },\n                        \"producer\": {\n                            \"enabled\": true,\n                            \"topic\": \"demo\",\n                            \"retained\": false\n                        }\n                    }\n                }\n            ]\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -601,17 +574,15 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
 										""
 									]
@@ -627,7 +598,7 @@
 									"script": {
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
-											"postman.setEnvironmentVariable(\"plan\", jsonData.id);"
+											"postman.setEnvironmentVariable(\"planId\", jsonData.id);"
 										],
 										"type": "text/javascript"
 									}
@@ -653,7 +624,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"name\":\"Keyless\",\n    \"description\":\"Keyless\",\n    \"characteristics\":[],\n    \"security\": {\n        \"type\": \"key-less\"\n    },\n    \"mode\": \"STANDARD\"\n}",
+									"raw": "{\n    \"definitionVersion\":\"V4\",\n    \"name\":\"Keyless\",\n    \"description\":\"Keyless\",\n    \"characteristics\":[],\n    \"security\": {\n        \"type\": \"KEY_LESS\"\n    },\n    \"mode\": \"STANDARD\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -661,19 +632,17 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"plans"
 									]
 								}
@@ -701,21 +670,19 @@
 								"method": "POST",
 								"header": [],
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans/{{plan}}/_publish",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans/{{planId}}/_publish",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"plans",
-										"{{plan}}",
+										"{{planId}}",
 										"_publish"
 									]
 								}
@@ -743,26 +710,18 @@
 								"method": "POST",
 								"header": [],
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/?action=start",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/_start",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
-										""
-									],
-									"query": [
-										{
-											"key": "action",
-											"value": "start"
-										}
+										"{{apiId}}",
+										"_start"
 									]
 								}
 							},
@@ -786,7 +745,7 @@
 									"script": {
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
-											"postman.setEnvironmentVariable(\"api\", jsonData.id);"
+											"postman.setEnvironmentVariable(\"apiId\", jsonData.id);"
 										],
 										"type": "text/javascript"
 									}
@@ -819,7 +778,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"name\": \"Event Consumption - SSE\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"4.0.0\",\n    \"type\": \"message\",\n    \"description\": \"Event Consumption - SSE\",\n    \"listeners\": [\n        {\n            \"type\": \"http\",\n            \"paths\": [\n                {\n                    \"path\": \"/demo/sse/kafka\"\n                }\n            ],\n            \"entrypoints\": [\n                {\n                    \"type\": \"sse\",\n                    \"qos\": \"at-least-once\",\n                    \"configuration\": {\n                        \"heartbeatIntervalInMs\": 5000,\n                        \"metadataAsComment\": false,\n                        \"headersAsComment\": false\n                    }\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"kafka\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"kafka\",\n                    \"weight\": 1,\n                    \"inheritConfiguration\": false,\n                    \"configuration\": {\n                        \"bootstrapServers\": \"kafka:9092\"\n                    },\n                    \"sharedConfigurationOverride\": {\n                        \"consumer\": {\n                            \"enabled\": true,\n                            \"topics\": [\n                                \"demo\"\n                            ]\n                        }\n                    }\n                }\n            ]\n        }\n    ]\n}",
+									"raw": "{\n    \"name\": \"Event Consumption - SSE\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"V4\",\n    \"type\": \"MESSAGE\",\n    \"description\": \"Event Consumption - SSE\",\n    \"listeners\": [\n        {\n            \"type\": \"HTTP\",\n            \"paths\": [\n                {\n                    \"path\": \"/demo/sse/kafka\"\n                }\n            ],\n            \"entrypoints\": [\n                {\n                    \"type\": \"sse\",\n                    \"qos\": \"AT_LEAST_ONCE\",\n                    \"configuration\": {\n                        \"heartbeatIntervalInMs\": 5000,\n                        \"metadataAsComment\": false,\n                        \"headersAsComment\": false\n                    }\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"kafka\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"kafka\",\n                    \"weight\": 1,\n                    \"inheritConfiguration\": false,\n                    \"configuration\": {\n                        \"bootstrapServers\": \"kafka:9092\"\n                    },\n                    \"sharedConfigurationOverride\": {\n                        \"consumer\": {\n                            \"enabled\": true,\n                            \"topics\": [\n                                \"demo\"\n                            ]\n                        }\n                    }\n                }\n            ]\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -827,17 +786,15 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
 										""
 									]
@@ -853,7 +810,7 @@
 									"script": {
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
-											"postman.setEnvironmentVariable(\"plan\", jsonData.id);"
+											"postman.setEnvironmentVariable(\"planId\", jsonData.id);"
 										],
 										"type": "text/javascript"
 									}
@@ -879,7 +836,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"name\":\"Keyless\",\n    \"description\":\"Keyless\",\n    \"characteristics\":[],\n    \"security\": {\n        \"type\": \"key-less\"\n    },\n    \"mode\": \"STANDARD\"\n}",
+									"raw": "{\n    \"definitionVersion\":\"V4\",\n    \"name\":\"Keyless\",\n    \"description\":\"Keyless\",\n    \"characteristics\":[],\n    \"security\": {\n        \"type\": \"KEY_LESS\"\n    },\n    \"mode\": \"STANDARD\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -887,19 +844,17 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"plans"
 									]
 								}
@@ -927,21 +882,19 @@
 								"method": "POST",
 								"header": [],
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans/{{plan}}/_publish",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans/{{planId}}/_publish",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"plans",
-										"{{plan}}",
+										"{{planId}}",
 										"_publish"
 									]
 								}
@@ -969,26 +922,18 @@
 								"method": "POST",
 								"header": [],
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/?action=start",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/_start",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
-										""
-									],
-									"query": [
-										{
-											"key": "action",
-											"value": "start"
-										}
+										"{{apiId}}",
+										"_start"
 									]
 								}
 							},
@@ -1007,7 +952,7 @@
 									"script": {
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
-											"postman.setEnvironmentVariable(\"api\", jsonData.id);"
+											"postman.setEnvironmentVariable(\"apiId\", jsonData.id);"
 										],
 										"type": "text/javascript"
 									}
@@ -1040,7 +985,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"name\": \"Event Consumption - SSE\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"4.0.0\",\n    \"type\": \"message\",\n    \"description\": \"Event Consumption - SSE\",\n    \"listeners\": [\n        {\n            \"type\": \"http\",\n            \"paths\": [\n                {\n                    \"path\": \"/demo/sse/kafka/plaintext\"\n                }\n            ],\n            \"entrypoints\": [\n                {\n                    \"type\": \"sse\",\n                    \"configuration\": {\n                        \"heartbeatIntervalInMs\": 5000,\n                        \"metadataAsComment\": false,\n                        \"headersAsComment\": false\n                    }\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"kafka\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"kafka\",\n                    \"weight\": 1,\n                    \"inheritConfiguration\": false,\n                    \"configuration\": {\n                        \"bootstrapServers\": \"kafka:9094\"\n                    },\n                    \"sharedConfigurationOverride\": {\n                        \"consumer\": {\n                            \"enabled\": true,\n                            \"topics\": [\n                                \"demo\"\n                            ]\n                        }\n                    }\n                }\n            ]\n        }\n    ]\n}",
+									"raw": "{\n    \"name\": \"Event Consumption - SSE\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"V4\",\n    \"type\": \"MESSAGE\",\n    \"description\": \"Event Consumption - SSE\",\n    \"listeners\": [\n        {\n            \"type\": \"HTTP\",\n            \"paths\": [\n                {\n                    \"path\": \"/demo/sse/kafka_plaintext\"\n                }\n            ],\n            \"entrypoints\": [\n                {\n                    \"type\": \"sse\",\n                    \"configuration\": {\n                        \"heartbeatIntervalInMs\": 5000,\n                        \"metadataAsComment\": false,\n                        \"headersAsComment\": false\n                    }\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"kafka\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"kafka\",\n                    \"weight\": 1,\n                    \"inheritConfiguration\": false,\n                    \"configuration\": {\n                        \"bootstrapServers\": \"kafka:9094\"\n                    },\n                    \"sharedConfigurationOverride\": {\n                        \"consumer\": {\n                            \"enabled\": true,\n                            \"topics\": [\n                                \"demo\"\n                            ]\n                        }\n                    }\n                }\n            ]\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -1048,17 +993,15 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
 										""
 									]
@@ -1074,7 +1017,7 @@
 									"script": {
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
-											"postman.setEnvironmentVariable(\"plan\", jsonData.id);"
+											"postman.setEnvironmentVariable(\"planId\", jsonData.id);"
 										],
 										"type": "text/javascript"
 									}
@@ -1100,7 +1043,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"name\":\"Keyless\",\n    \"description\":\"Keyless\",\n    \"characteristics\":[],\n    \"security\": {\n        \"type\": \"key-less\"\n    },\n    \"mode\": \"STANDARD\"\n}",
+									"raw": "{\n    \"definitionVersion\":\"V4\",\n    \"name\":\"Keyless\",\n    \"description\":\"Keyless\",\n    \"characteristics\":[],\n    \"security\": {\n        \"type\": \"KEY_LESS\"\n    },\n    \"mode\": \"STANDARD\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -1108,19 +1051,17 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"plans"
 									]
 								}
@@ -1148,21 +1089,19 @@
 								"method": "POST",
 								"header": [],
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans/{{plan}}/_publish",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans/{{planId}}/_publish",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"plans",
-										"{{plan}}",
+										"{{planId}}",
 										"_publish"
 									]
 								}
@@ -1190,26 +1129,18 @@
 								"method": "POST",
 								"header": [],
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/?action=start",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/_start",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
-										""
-									],
-									"query": [
-										{
-											"key": "action",
-											"value": "start"
-										}
+										"{{apiId}}",
+										"_start"
 									]
 								}
 							},
@@ -1228,7 +1159,7 @@
 									"script": {
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
-											"postman.setEnvironmentVariable(\"api\", jsonData.id);"
+											"postman.setEnvironmentVariable(\"apiId\", jsonData.id);"
 										],
 										"type": "text/javascript"
 									}
@@ -1261,7 +1192,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"name\": \"Event Consumption - SSE\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"4.0.0\",\n    \"type\": \"message\",\n    \"description\": \"Event Consumption - SSE\",\n    \"listeners\": [\n        {\n            \"type\": \"http\",\n            \"paths\": [\n                {\n                    \"path\": \"/demo/sse/kafka/sasl_plaintext\"\n                }\n            ],\n            \"entrypoints\": [\n                {\n                    \"type\": \"sse\",\n                    \"configuration\": {\n                        \"heartbeatIntervalInMs\": 5000,\n                        \"metadataAsComment\": false,\n                        \"headersAsComment\": false\n                    }\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"kafka\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"kafka\",\n                    \"weight\": 1,\n                    \"inheritConfiguration\": false,\n                    \"configuration\": {\n                        \"bootstrapServers\": \"kafka:9095\"\n                    },\n                    \"sharedConfigurationOverride\": {\n                        \"security\": {\n                            \"protocol\": \"SASL_PLAINTEXT\",\n                            \"sasl\": {\n                                \"saslMechanism\": \"PLAIN\",\n                                \"saslJaasConfig\": \"org.apache.kafka.common.security.plain.PlainLoginModule required username=\\\"gravitee_user\\\" password=\\\"gravitee_password\\\";\"\n                            }\n                        },\n                        \"consumer\": {\n                            \"enabled\": true,\n                            \"topics\": [\n                                \"demo\"\n                            ]\n                        }\n                    }\n                }\n            ]\n        }\n    ]\n}",
+									"raw": "{\n    \"name\": \"Event Consumption - SSE\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"V4\",\n    \"type\": \"MESSAGE\",\n    \"description\": \"Event Consumption - SSE\",\n    \"listeners\": [\n        {\n            \"type\": \"HTTP\",\n            \"paths\": [\n                {\n                    \"path\": \"/demo/sse/kafka_sasl_plaintext\"\n                }\n            ],\n            \"entrypoints\": [\n                {\n                    \"type\": \"sse\",\n                    \"configuration\": {\n                        \"heartbeatIntervalInMs\": 5000,\n                        \"metadataAsComment\": false,\n                        \"headersAsComment\": false\n                    }\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"kafka\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"kafka\",\n                    \"weight\": 1,\n                    \"inheritConfiguration\": false,\n                    \"configuration\": {\n                        \"bootstrapServers\": \"kafka:9095\"\n                    },\n                    \"sharedConfigurationOverride\": {\n                        \"security\": {\n                            \"protocol\": \"SASL_PLAINTEXT\",\n                            \"sasl\": {\n                                \"saslMechanism\": \"PLAIN\",\n                                \"saslJaasConfig\": \"org.apache.kafka.common.security.plain.PlainLoginModule required username=\\\"gravitee_user\\\" password=\\\"gravitee_password\\\";\"\n                            }\n                        },\n                        \"consumer\": {\n                            \"enabled\": true,\n                            \"topics\": [\n                                \"demo\"\n                            ]\n                        }\n                    }\n                }\n            ]\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -1269,17 +1200,15 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
 										""
 									]
@@ -1295,7 +1224,7 @@
 									"script": {
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
-											"postman.setEnvironmentVariable(\"plan\", jsonData.id);"
+											"postman.setEnvironmentVariable(\"planId\", jsonData.id);"
 										],
 										"type": "text/javascript"
 									}
@@ -1321,7 +1250,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"name\":\"Keyless\",\n    \"description\":\"Keyless\",\n    \"characteristics\":[],\n    \"security\": {\n        \"type\": \"key-less\"\n    },\n    \"mode\": \"STANDARD\"\n}",
+									"raw": "{\n    \"definitionVersion\":\"V4\",\n    \"name\":\"Keyless\",\n    \"description\":\"Keyless\",\n    \"characteristics\":[],\n    \"security\": {\n        \"type\": \"KEY_LESS\"\n    },\n    \"mode\": \"STANDARD\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -1329,19 +1258,17 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"plans"
 									]
 								}
@@ -1369,21 +1296,19 @@
 								"method": "POST",
 								"header": [],
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans/{{plan}}/_publish",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans/{{planId}}/_publish",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"plans",
-										"{{plan}}",
+										"{{planId}}",
 										"_publish"
 									]
 								}
@@ -1411,26 +1336,18 @@
 								"method": "POST",
 								"header": [],
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/?action=start",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/_start",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
-										""
-									],
-									"query": [
-										{
-											"key": "action",
-											"value": "start"
-										}
+										"{{apiId}}",
+										"_start"
 									]
 								}
 							},
@@ -1449,7 +1366,7 @@
 									"script": {
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
-											"postman.setEnvironmentVariable(\"api\", jsonData.id);"
+											"postman.setEnvironmentVariable(\"apiId\", jsonData.id);"
 										],
 										"type": "text/javascript"
 									}
@@ -1482,7 +1399,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"name\": \"Event Consumption - SSE\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"4.0.0\",\n    \"type\": \"message\",\n    \"description\": \"Event Consumption - SSE\",\n    \"listeners\": [\n        {\n            \"type\": \"http\",\n            \"paths\": [\n                {\n                    \"path\": \"/demo/sse/kafka/sasl_ssl\"\n                }\n            ],\n            \"entrypoints\": [\n                {\n                    \"type\": \"sse\",\n                    \"configuration\": {\n                        \"heartbeatIntervalInMs\": 5000,\n                        \"metadataAsComment\": false,\n                        \"headersAsComment\": false\n                    }\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"kafka\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"kafka\",\n                    \"weight\": 1,\n                    \"inheritConfiguration\": false,\n                    \"configuration\": {\n                        \"bootstrapServers\": \"kafka:9096\"\n                    },\n                    \"sharedConfigurationOverride\": {\n                        \"security\": {\n                            \"protocol\": \"SASL_SSL\",\n                            \"sasl\": {\n                                \"saslMechanism\": \"PLAIN\",\n                                \"saslJaasConfig\": \"org.apache.kafka.common.security.plain.PlainLoginModule required username=\\\"gravitee_user\\\" password=\\\"gravitee_password\\\";\"\n                            },\n                            \"ssl\": {\n                                \"trustStore\": {\n                                    \"type\": \"JKS\",\n                                    \"location\": \"/opt/graviteeio-gateway/config/ssl/client.truststore.jks\",\n                                    \"password\": \"gravitee\"\n                                }\n                            }\n                        },\n                        \"consumer\": {\n                            \"enabled\": true,\n                            \"topics\": [\n                                \"demo\"\n                            ]\n                        }\n                    }\n                }\n            ]\n        }\n    ]\n}",
+									"raw": "{\n    \"name\": \"Event Consumption - SSE\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"V4\",\n    \"type\": \"MESSAGE\",\n    \"description\": \"Event Consumption - SSE\",\n    \"listeners\": [\n        {\n            \"type\": \"HTTP\",\n            \"paths\": [\n                {\n                    \"path\": \"/demo/sse/kafka_sasl_ssl\"\n                }\n            ],\n            \"entrypoints\": [\n                {\n                    \"type\": \"sse\",\n                    \"configuration\": {\n                        \"heartbeatIntervalInMs\": 5000,\n                        \"metadataAsComment\": false,\n                        \"headersAsComment\": false\n                    }\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"kafka\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"kafka\",\n                    \"weight\": 1,\n                    \"inheritConfiguration\": false,\n                    \"configuration\": {\n                        \"bootstrapServers\": \"kafka:9096\"\n                    },\n                    \"sharedConfigurationOverride\": {\n                        \"security\": {\n                            \"protocol\": \"SASL_SSL\",\n                            \"sasl\": {\n                                \"saslMechanism\": \"PLAIN\",\n                                \"saslJaasConfig\": \"org.apache.kafka.common.security.plain.PlainLoginModule required username=\\\"gravitee_user\\\" password=\\\"gravitee_password\\\";\"\n                            },\n                            \"ssl\": {\n                                \"trustStore\": {\n                                    \"type\": \"JKS\",\n                                    \"location\": \"/opt/graviteeio-gateway/config/ssl/client.truststore.jks\",\n                                    \"password\": \"gravitee\"\n                                }\n                            }\n                        },\n                        \"consumer\": {\n                            \"enabled\": true,\n                            \"topics\": [\n                                \"demo\"\n                            ]\n                        }\n                    }\n                }\n            ]\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -1490,17 +1407,15 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
 										""
 									]
@@ -1516,7 +1431,7 @@
 									"script": {
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
-											"postman.setEnvironmentVariable(\"plan\", jsonData.id);"
+											"postman.setEnvironmentVariable(\"planId\", jsonData.id);"
 										],
 										"type": "text/javascript"
 									}
@@ -1542,7 +1457,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"name\":\"Keyless\",\n    \"description\":\"Keyless\",\n    \"characteristics\":[],\n    \"security\": {\n        \"type\": \"key-less\"\n    },\n    \"mode\": \"STANDARD\"\n}",
+									"raw": "{\n    \"definitionVersion\":\"V4\",\n    \"name\":\"Keyless\",\n    \"description\":\"Keyless\",\n    \"characteristics\":[],\n    \"security\": {\n        \"type\": \"KEY_LESS\"\n    },\n    \"mode\": \"STANDARD\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -1550,19 +1465,17 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"plans"
 									]
 								}
@@ -1590,21 +1503,19 @@
 								"method": "POST",
 								"header": [],
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans/{{plan}}/_publish",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans/{{planId}}/_publish",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"plans",
-										"{{plan}}",
+										"{{planId}}",
 										"_publish"
 									]
 								}
@@ -1632,26 +1543,18 @@
 								"method": "POST",
 								"header": [],
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/?action=start",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/_start",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
-										""
-									],
-									"query": [
-										{
-											"key": "action",
-											"value": "start"
-										}
+										"{{apiId}}",
+										"_start"
 									]
 								}
 							},
@@ -1670,7 +1573,7 @@
 									"script": {
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
-											"postman.setEnvironmentVariable(\"api\", jsonData.id);"
+											"postman.setEnvironmentVariable(\"apiId\", jsonData.id);"
 										],
 										"type": "text/javascript"
 									}
@@ -1703,7 +1606,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"name\": \"Event Consumption - SSE\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"4.0.0\",\n    \"type\": \"message\",\n    \"description\": \"Event Consumption - SSE\",\n    \"listeners\": [\n        {\n            \"type\": \"http\",\n            \"paths\": [\n                {\n                    \"path\": \"/demo/sse/kafka/ssl\"\n                }\n            ],\n            \"entrypoints\": [\n                {\n                    \"type\": \"sse\",\n                    \"configuration\": {\n                        \"heartbeatIntervalInMs\": 5000,\n                        \"metadataAsComment\": false,\n                        \"headersAsComment\": false\n                    }\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"kafka\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"kafka\",\n                    \"weight\": 1,\n                    \"inheritConfiguration\": false,\n                    \"configuration\": {\n                        \"bootstrapServers\": \"kafka:9094\"\n                    },\n                    \"sharedConfigurationOverride\": {\n                        \"security\": {\n                            \"protocol\": \"SSL\",\n                            \"ssl\": {\n                                \"trustStore\": {\n                                    \"type\": \"JKS\",\n                                    \"location\": \"/opt/graviteeio-gateway/config/ssl/client.truststore.jks\",\n                                    \"password\": \"gravitee\"\n                                },\n                                \"keyStore\": {\n                                    \"type\": \"JKS\",\n                                    \"location\": \"/opt/graviteeio-gateway/config/ssl/client.keystore.jks\",\n                                    \"password\": \"gravitee\"\n                                }\n                            }\n                        },\n                        \"consumer\": {\n                            \"enabled\": true,\n                            \"topics\": [\n                                \"demo\"\n                            ]\n                        }\n                    }\n                }\n            ]\n        }\n    ]\n}",
+									"raw": "{\n    \"name\": \"Event Consumption - SSE\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"V4\",\n    \"type\": \"MESSAGE\",\n    \"description\": \"Event Consumption - SSE\",\n    \"listeners\": [\n        {\n            \"type\": \"HTTP\",\n            \"paths\": [\n                {\n                    \"path\": \"/demo/sse/kafka_ssl\"\n                }\n            ],\n            \"entrypoints\": [\n                {\n                    \"type\": \"sse\",\n                    \"configuration\": {\n                        \"heartbeatIntervalInMs\": 5000,\n                        \"metadataAsComment\": false,\n                        \"headersAsComment\": false\n                    }\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"kafka\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"kafka\",\n                    \"weight\": 1,\n                    \"inheritConfiguration\": false,\n                    \"configuration\": {\n                        \"bootstrapServers\": \"kafka:9094\"\n                    },\n                    \"sharedConfigurationOverride\": {\n                        \"security\": {\n                            \"protocol\": \"SSL\",\n                            \"ssl\": {\n                                \"trustStore\": {\n                                    \"type\": \"JKS\",\n                                    \"location\": \"/opt/graviteeio-gateway/config/ssl/client.truststore.jks\",\n                                    \"password\": \"gravitee\"\n                                },\n                                \"keyStore\": {\n                                    \"type\": \"JKS\",\n                                    \"location\": \"/opt/graviteeio-gateway/config/ssl/client.keystore.jks\",\n                                    \"password\": \"gravitee\"\n                                }\n                            }\n                        },\n                        \"consumer\": {\n                            \"enabled\": true,\n                            \"topics\": [\n                                \"demo\"\n                            ]\n                        }\n                    }\n                }\n            ]\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -1711,17 +1614,15 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
 										""
 									]
@@ -1737,7 +1638,7 @@
 									"script": {
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
-											"postman.setEnvironmentVariable(\"plan\", jsonData.id);"
+											"postman.setEnvironmentVariable(\"planId\", jsonData.id);"
 										],
 										"type": "text/javascript"
 									}
@@ -1763,7 +1664,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"name\":\"Keyless\",\n    \"description\":\"Keyless\",\n    \"characteristics\":[],\n    \"security\": {\n        \"type\": \"key-less\"\n    },\n    \"mode\": \"STANDARD\"\n}",
+									"raw": "{\n    \"definitionVersion\":\"V4\",\n    \"name\":\"Keyless\",\n    \"description\":\"Keyless\",\n    \"characteristics\":[],\n    \"security\": {\n        \"type\": \"KEY_LESS\"\n    },\n    \"mode\": \"STANDARD\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -1771,19 +1672,17 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"plans"
 									]
 								}
@@ -1811,21 +1710,19 @@
 								"method": "POST",
 								"header": [],
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans/{{plan}}/_publish",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans/{{planId}}/_publish",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"plans",
-										"{{plan}}",
+										"{{planId}}",
 										"_publish"
 									]
 								}
@@ -1853,26 +1750,18 @@
 								"method": "POST",
 								"header": [],
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/?action=start",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/_start",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
-										""
-									],
-									"query": [
-										{
-											"key": "action",
-											"value": "start"
-										}
+										"{{apiId}}",
+										"_start"
 									]
 								}
 							},
@@ -1891,7 +1780,7 @@
 									"script": {
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
-											"postman.setEnvironmentVariable(\"api\", jsonData.id);"
+											"postman.setEnvironmentVariable(\"apiId\", jsonData.id);"
 										],
 										"type": "text/javascript"
 									}
@@ -1924,7 +1813,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"name\": \"Event Consumption - SSE\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"4.0.0\",\n    \"type\": \"message\",\n    \"description\": \"Event Consumption - SSE from MQTT 5.x\",\n    \"listeners\": [\n        {\n            \"type\": \"http\",\n            \"paths\": [\n                {\n                    \"path\": \"/demo/sse/mqtt5\"\n                }\n            ],\n            \"entrypoints\": [\n                {\n                    \"type\": \"sse\",\n                    \"configuration\": {\n                        \"heartbeatIntervalInMs\": 5000,\n                        \"metadataAsComment\": false,\n                        \"headersAsComment\": false\n                    }\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"mqtt5\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"mqtt5\",\n                    \"weight\": 1,\n                    \"inheritConfiguration\": false,\n                    \"configuration\": {\n                        \"serverHost\": \"hivemq\",\n                        \"serverPort\": 1883\n                    },\n                    \"sharedConfigurationOverride\": {\n                        \"consumer\": {\n                            \"enabled\": true,\n                            \"topic\": \"demo\"\n                        }\n                    }\n                }\n            ]\n        }\n    ]\n}",
+									"raw": "{\n    \"name\": \"Event Consumption - SSE\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"V4\",\n    \"type\": \"MESSAGE\",\n    \"description\": \"Event Consumption - SSE from MQTT 5.x\",\n    \"listeners\": [\n        {\n            \"type\": \"HTTP\",\n            \"paths\": [\n                {\n                    \"path\": \"/demo/sse/mqtt5\"\n                }\n            ],\n            \"entrypoints\": [\n                {\n                    \"type\": \"sse\",\n                    \"configuration\": {\n                        \"heartbeatIntervalInMs\": 5000,\n                        \"metadataAsComment\": false,\n                        \"headersAsComment\": false\n                    }\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"mqtt5\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"mqtt5\",\n                    \"weight\": 1,\n                    \"inheritConfiguration\": false,\n                    \"configuration\": {\n                        \"serverHost\": \"hivemq\",\n                        \"serverPort\": 1883\n                    },\n                    \"sharedConfigurationOverride\": {\n                        \"consumer\": {\n                            \"enabled\": true,\n                            \"topic\": \"demo\"\n                        }\n                    }\n                }\n            ]\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -1932,17 +1821,15 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
 										""
 									]
@@ -1958,7 +1845,7 @@
 									"script": {
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
-											"postman.setEnvironmentVariable(\"plan\", jsonData.id);"
+											"postman.setEnvironmentVariable(\"planId\", jsonData.id);"
 										],
 										"type": "text/javascript"
 									}
@@ -1984,7 +1871,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"name\":\"Keyless\",\n    \"description\":\"Keyless\",\n    \"characteristics\":[],\n    \"security\": {\n        \"type\": \"key-less\"\n    },\n    \"mode\": \"STANDARD\"\n}",
+									"raw": "{\n    \"definitionVersion\":\"V4\",\n    \"name\":\"Keyless\",\n    \"description\":\"Keyless\",\n    \"characteristics\":[],\n    \"security\": {\n        \"type\": \"KEY_LESS\"\n    },\n    \"mode\": \"STANDARD\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -1992,19 +1879,17 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"plans"
 									]
 								}
@@ -2032,21 +1917,19 @@
 								"method": "POST",
 								"header": [],
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans/{{plan}}/_publish",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans/{{planId}}/_publish",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"plans",
-										"{{plan}}",
+										"{{planId}}",
 										"_publish"
 									]
 								}
@@ -2074,26 +1957,18 @@
 								"method": "POST",
 								"header": [],
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/?action=start",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/_start",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
-										""
-									],
-									"query": [
-										{
-											"key": "action",
-											"value": "start"
-										}
+										"{{apiId}}",
+										"_start"
 									]
 								}
 							},
@@ -2112,7 +1987,7 @@
 									"script": {
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
-											"postman.setEnvironmentVariable(\"api\", jsonData.id);"
+											"postman.setEnvironmentVariable(\"apiId\", jsonData.id);"
 										],
 										"type": "text/javascript"
 									}
@@ -2145,7 +2020,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"name\": \"Event Consumption - SSE from MQTT 5.x Auth\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"4.0.0\",\n    \"type\": \"message\",\n    \"description\": \"Event Consumption - SSE from MQTT 5.x Auth\",\n    \"listeners\": [\n        {\n            \"type\": \"http\",\n            \"paths\": [\n                {\n                    \"path\": \"/demo/sse/mqtt5-auth\"\n                }\n            ],\n            \"entrypoints\": [\n                {\n                    \"type\": \"sse\",\n                    \"configuration\": {\n                        \"heartbeatIntervalInMs\": 5000,\n                        \"metadataAsComment\": false,\n                        \"headersAsComment\": false\n                    }\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"mqtt5\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"mqtt5\",\n                    \"weight\": 1,\n                    \"inheritConfiguration\": false,\n                    \"configuration\": {\n                        \"serverHost\": \"hivemq\",\n                        \"serverPort\": 1883\n                    },\n                    \"sharedConfigurationOverride\": {\n                        \"security\": {\n                            \"auth\": {\n                                \"username\": \"admin-user\",\n                                \"password\": \"admin-password\"\n                            }\n                        },\n                        \"consumer\": {\n                            \"enabled\": true,\n                            \"topic\": \"demo\"\n                        }\n                    }\n                }\n            ]\n        }\n    ]\n}",
+									"raw": "{\n    \"name\": \"Event Consumption - SSE from MQTT 5.x Auth\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"V4\",\n    \"type\": \"MESSAGE\",\n    \"description\": \"Event Consumption - SSE from MQTT 5.x Auth\",\n    \"listeners\": [\n        {\n            \"type\": \"HTTP\",\n            \"paths\": [\n                {\n                    \"path\": \"/demo/sse/mqtt5-auth\"\n                }\n            ],\n            \"entrypoints\": [\n                {\n                    \"type\": \"sse\",\n                    \"configuration\": {\n                        \"heartbeatIntervalInMs\": 5000,\n                        \"metadataAsComment\": false,\n                        \"headersAsComment\": false\n                    }\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"mqtt5\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"mqtt5\",\n                    \"weight\": 1,\n                    \"inheritConfiguration\": false,\n                    \"configuration\": {\n                        \"serverHost\": \"hivemq\",\n                        \"serverPort\": 1883\n                    },\n                    \"sharedConfigurationOverride\": {\n                        \"security\": {\n                            \"auth\": {\n                                \"username\": \"admin-user\",\n                                \"password\": \"admin-password\"\n                            }\n                        },\n                        \"consumer\": {\n                            \"enabled\": true,\n                            \"topic\": \"demo\"\n                        }\n                    }\n                }\n            ]\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -2153,17 +2028,15 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
 										""
 									]
@@ -2179,7 +2052,7 @@
 									"script": {
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
-											"postman.setEnvironmentVariable(\"plan\", jsonData.id);"
+											"postman.setEnvironmentVariable(\"planId\", jsonData.id);"
 										],
 										"type": "text/javascript"
 									}
@@ -2205,7 +2078,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"name\":\"Keyless\",\n    \"description\":\"Keyless\",\n    \"characteristics\":[],\n    \"security\": {\n        \"type\": \"key-less\"\n    },\n    \"mode\": \"STANDARD\"\n}",
+									"raw": "{\n    \"definitionVersion\":\"V4\",\n    \"name\":\"Keyless\",\n    \"description\":\"Keyless\",\n    \"characteristics\":[],\n    \"security\": {\n        \"type\": \"KEY_LESS\"\n    },\n    \"mode\": \"STANDARD\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -2213,19 +2086,17 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"plans"
 									]
 								}
@@ -2253,21 +2124,19 @@
 								"method": "POST",
 								"header": [],
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans/{{plan}}/_publish",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans/{{planId}}/_publish",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"plans",
-										"{{plan}}",
+										"{{planId}}",
 										"_publish"
 									]
 								}
@@ -2295,26 +2164,18 @@
 								"method": "POST",
 								"header": [],
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/?action=start",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/_start",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
-										""
-									],
-									"query": [
-										{
-											"key": "action",
-											"value": "start"
-										}
+										"{{apiId}}",
+										"_start"
 									]
 								}
 							},
@@ -2333,7 +2194,7 @@
 									"script": {
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
-											"postman.setEnvironmentVariable(\"api\", jsonData.id);"
+											"postman.setEnvironmentVariable(\"apiId\", jsonData.id);"
 										],
 										"type": "text/javascript"
 									}
@@ -2366,7 +2227,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"name\": \"Event Consumption - SSE from MQTT 5.x Auth TLS\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"4.0.0\",\n    \"type\": \"message\",\n    \"description\": \"Event Consumption - SSE from MQTT 5.x Auth TLS\",\n    \"listeners\": [\n        {\n            \"type\": \"http\",\n            \"paths\": [\n                {\n                    \"path\": \"/demo/sse/mqtt5-auth-tls\"\n                }\n            ],\n            \"entrypoints\": [\n                {\n                    \"type\": \"sse\",\n                    \"configuration\": {\n                        \"heartbeatIntervalInMs\": 5000,\n                        \"metadataAsComment\": false,\n                        \"headersAsComment\": false\n                    }\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"mqtt5\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"mqtt5\",\n                    \"weight\": 1,\n                    \"inheritConfiguration\": false,\n                    \"configuration\": {\n                        \"serverHost\": \"hivemq\",\n                        \"serverPort\": 8883\n                    },\n                    \"sharedConfigurationOverride\": {\n                        \"security\": {\n                            \"auth\": {\n                                \"username\": \"admin-user\",\n                                \"password\": \"admin-password\"\n                            },\n                            \"ssl\": {\n                                \"trustStore\": {\n                                    \"type\": \"PKCS12\",\n                                    \"path\": \"/opt/graviteeio-gateway/ssl/certs/hivemq-server.p12\",\n                                    \"password\": \"gravitee\"\n                                }\n                            }\n                        },\n                        \"consumer\": {\n                            \"enabled\": true,\n                            \"topic\": \"demo\"\n                        }\n                    }\n                }\n            ]\n        }\n    ]\n}",
+									"raw": "{\n    \"name\": \"Event Consumption - SSE from MQTT 5.x Auth TLS\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"V4\",\n    \"type\": \"MESSAGE\",\n    \"description\": \"Event Consumption - SSE from MQTT 5.x Auth TLS\",\n    \"listeners\": [\n        {\n            \"type\": \"HTTP\",\n            \"paths\": [\n                {\n                    \"path\": \"/demo/sse/mqtt5-auth-tls\"\n                }\n            ],\n            \"entrypoints\": [\n                {\n                    \"type\": \"sse\",\n                    \"configuration\": {\n                        \"heartbeatIntervalInMs\": 5000,\n                        \"metadataAsComment\": false,\n                        \"headersAsComment\": false\n                    }\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"mqtt5\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"mqtt5\",\n                    \"weight\": 1,\n                    \"inheritConfiguration\": false,\n                    \"configuration\": {\n                        \"serverHost\": \"hivemq\",\n                        \"serverPort\": 8883\n                    },\n                    \"sharedConfigurationOverride\": {\n                        \"security\": {\n                            \"auth\": {\n                                \"username\": \"admin-user\",\n                                \"password\": \"admin-password\"\n                            },\n                            \"ssl\": {\n                                \"trustStore\": {\n                                    \"type\": \"PKCS12\",\n                                    \"path\": \"/opt/graviteeio-gateway/ssl/certs/hivemq-server.p12\",\n                                    \"password\": \"gravitee\"\n                                }\n                            }\n                        },\n                        \"consumer\": {\n                            \"enabled\": true,\n                            \"topic\": \"demo\"\n                        }\n                    }\n                }\n            ]\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -2374,17 +2235,15 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
 										""
 									]
@@ -2400,7 +2259,7 @@
 									"script": {
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
-											"postman.setEnvironmentVariable(\"plan\", jsonData.id);"
+											"postman.setEnvironmentVariable(\"planId\", jsonData.id);"
 										],
 										"type": "text/javascript"
 									}
@@ -2426,7 +2285,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"name\":\"Keyless\",\n    \"description\":\"Keyless\",\n    \"characteristics\":[],\n    \"security\": {\n        \"type\": \"key-less\"\n    },\n    \"mode\": \"STANDARD\"\n}",
+									"raw": "{\n    \"definitionVersion\":\"V4\",\n    \"name\":\"Keyless\",\n    \"description\":\"Keyless\",\n    \"characteristics\":[],\n    \"security\": {\n        \"type\": \"KEY_LESS\"\n    },\n    \"mode\": \"STANDARD\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -2434,19 +2293,17 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"plans"
 									]
 								}
@@ -2474,21 +2331,19 @@
 								"method": "POST",
 								"header": [],
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans/{{plan}}/_publish",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans/{{planId}}/_publish",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"plans",
-										"{{plan}}",
+										"{{planId}}",
 										"_publish"
 									]
 								}
@@ -2516,26 +2371,18 @@
 								"method": "POST",
 								"header": [],
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/?action=start",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/_start",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
-										""
-									],
-									"query": [
-										{
-											"key": "action",
-											"value": "start"
-										}
+										"{{apiId}}",
+										"_start"
 									]
 								}
 							},
@@ -2554,7 +2401,7 @@
 									"script": {
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
-											"postman.setEnvironmentVariable(\"api\", jsonData.id);"
+											"postman.setEnvironmentVariable(\"apiId\", jsonData.id);"
 										],
 										"type": "text/javascript"
 									}
@@ -2587,7 +2434,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"name\": \"Event Consumption - SSE from MQTT 5.x with mTLS\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"4.0.0\",\n    \"type\": \"message\",\n    \"description\": \"Event Consumption - SSE from MQTT 5.x with mTLS\",\n    \"listeners\": [\n        {\n            \"type\": \"http\",\n            \"paths\": [\n                {\n                    \"path\": \"/demo/sse/mqtt5-auth-mtls\"\n                }\n            ],\n            \"entrypoints\": [\n                {\n                    \"type\": \"sse\",\n                    \"configuration\": {\n                        \"heartbeatIntervalInMs\": 5000,\n                        \"metadataAsComment\": false,\n                        \"headersAsComment\": false\n                    }\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"mqtt5\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"mqtt5\",\n                    \"weight\": 1,\n                    \"inheritConfiguration\": false,\n                    \"configuration\": {\n                        \"serverHost\": \"hivemq\",\n                        \"serverPort\": 9883\n                    },\n                    \"sharedConfigurationOverride\": {\n                        \"security\": {\n                            \n                            \"ssl\": {\n                                \"trustStore\": {\n                                    \"type\": \"PKCS12\",\n                                    \"path\": \"/opt/graviteeio-gateway/ssl/certs/hivemq-server.p12\",\n                                    \"password\": \"gravitee\"\n                                },\n                                \"keyStore\": {\n                                    \"type\": \"PKCS12\",\n                                    \"path\": \"/opt/graviteeio-gateway/ssl/certs/client.p12\",\n                                    \"password\": \"gravitee\"\n                                }\n                            }\n                        },\n                        \"consumer\": {\n                            \"enabled\": true,\n                            \"topic\": \"demo\"\n                        }\n                    }\n                }\n            ]\n        }\n    ]\n}",
+									"raw": "{\n    \"name\": \"Event Consumption - SSE from MQTT 5.x with mTLS\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"V4\",\n    \"type\": \"MESSAGE\",\n    \"description\": \"Event Consumption - SSE from MQTT 5.x with mTLS\",\n    \"listeners\": [\n        {\n            \"type\": \"HTTP\",\n            \"paths\": [\n                {\n                    \"path\": \"/demo/sse/mqtt5-auth-mtls\"\n                }\n            ],\n            \"entrypoints\": [\n                {\n                    \"type\": \"sse\",\n                    \"configuration\": {\n                        \"heartbeatIntervalInMs\": 5000,\n                        \"metadataAsComment\": false,\n                        \"headersAsComment\": false\n                    }\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"mqtt5\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"mqtt5\",\n                    \"weight\": 1,\n                    \"inheritConfiguration\": false,\n                    \"configuration\": {\n                        \"serverHost\": \"hivemq\",\n                        \"serverPort\": 9883\n                    },\n                    \"sharedConfigurationOverride\": {\n                        \"security\": {\n                            \n                            \"ssl\": {\n                                \"trustStore\": {\n                                    \"type\": \"PKCS12\",\n                                    \"path\": \"/opt/graviteeio-gateway/ssl/certs/hivemq-server.p12\",\n                                    \"password\": \"gravitee\"\n                                },\n                                \"keyStore\": {\n                                    \"type\": \"PKCS12\",\n                                    \"path\": \"/opt/graviteeio-gateway/ssl/certs/client.p12\",\n                                    \"password\": \"gravitee\"\n                                }\n                            }\n                        },\n                        \"consumer\": {\n                            \"enabled\": true,\n                            \"topic\": \"demo\"\n                        }\n                    }\n                }\n            ]\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -2595,17 +2442,15 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
 										""
 									]
@@ -2621,7 +2466,7 @@
 									"script": {
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
-											"postman.setEnvironmentVariable(\"plan\", jsonData.id);"
+											"postman.setEnvironmentVariable(\"planId\", jsonData.id);"
 										],
 										"type": "text/javascript"
 									}
@@ -2647,7 +2492,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"name\":\"Keyless\",\n    \"description\":\"Keyless\",\n    \"characteristics\":[],\n    \"security\": {\n        \"type\": \"key-less\"\n    },\n    \"mode\": \"STANDARD\"\n}",
+									"raw": "{\n    \"definitionVersion\":\"V4\",\n    \"name\":\"Keyless\",\n    \"description\":\"Keyless\",\n    \"characteristics\":[],\n    \"security\": {\n        \"type\": \"KEY_LESS\"\n    },\n    \"mode\": \"STANDARD\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -2655,19 +2500,17 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"plans"
 									]
 								}
@@ -2695,21 +2538,19 @@
 								"method": "POST",
 								"header": [],
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans/{{plan}}/_publish",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans/{{planId}}/_publish",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"plans",
-										"{{plan}}",
+										"{{planId}}",
 										"_publish"
 									]
 								}
@@ -2737,26 +2578,18 @@
 								"method": "POST",
 								"header": [],
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/?action=start",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/_start",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
-										""
-									],
-									"query": [
-										{
-											"key": "action",
-											"value": "start"
-										}
+										"{{apiId}}",
+										"_start"
 									]
 								}
 							},
@@ -2777,7 +2610,7 @@
 							"script": {
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
-									"postman.setEnvironmentVariable(\"api\", jsonData.id);"
+									"postman.setEnvironmentVariable(\"apiId\", jsonData.id);"
 								],
 								"type": "text/javascript"
 							}
@@ -2810,7 +2643,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"name\": \"Event Consumption - Websocket\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"4.0.0\",\n    \"type\": \"message\",\n    \"description\": \"Event Consumption - Websocket\",\n    \"listeners\": [\n        {\n            \"type\": \"http\",\n            \"paths\": [\n                {\n                    \"path\": \"/demo/ws\"\n                }\n            ],\n            \"entrypoints\": [\n                {\n                    \"type\": \"websocket\",\n                    \"configuration\": {\n                        \"publisher\": {\n                            \"enabled\": true\n                        },\n                        \"subscriber\": {\n                            \"enabled\": true\n                        }\n                    }\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"kafka\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"kafka\",\n                    \"weight\": 1,\n                    \"inheritConfiguration\": false,\n                    \"configuration\": {\n                        \"bootstrapServers\": \"kafka:9092\"\n                    },\n                    \"sharedConfigurationOverride\": {\n                        \"consumer\": {\n                            \"enabled\": true,\n                            \"topics\": [\n                                \"demo\"\n                            ],\n                            \"autoOffsetReset\": \"earliest\"\n                        }\n                    }\n                }\n            ]\n        }\n    ]\n}",
+							"raw": "{\n    \"name\": \"Event Consumption - Websocket\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"V4\",\n    \"type\": \"MESSAGE\",\n    \"description\": \"Event Consumption - Websocket\",\n    \"listeners\": [\n        {\n            \"type\": \"HTTP\",\n            \"paths\": [\n                {\n                    \"path\": \"/demo/ws\"\n                }\n            ],\n            \"entrypoints\": [\n                {\n                    \"type\": \"websocket\",\n                    \"configuration\": {\n                        \"publisher\": {\n                            \"enabled\": true\n                        },\n                        \"subscriber\": {\n                            \"enabled\": true\n                        }\n                    }\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"kafka\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"kafka\",\n                    \"weight\": 1,\n                    \"inheritConfiguration\": false,\n                    \"configuration\": {\n                        \"bootstrapServers\": \"kafka:9092\"\n                    },\n                    \"sharedConfigurationOverride\": {\n                        \"consumer\": {\n                            \"enabled\": true,\n                            \"topics\": [\n                                \"demo\"\n                            ],\n                            \"autoOffsetReset\": \"earliest\"\n                        }\n                    }\n                }\n            ]\n        }\n    ]\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -2818,17 +2651,15 @@
 							}
 						},
 						"url": {
-							"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/",
+							"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/",
 							"host": [
 								"{{management_host}}"
 							],
 							"path": [
 								"management",
-								"organizations",
-								"DEFAULT",
+								"v2",
 								"environments",
 								"DEFAULT",
-								"v4",
 								"apis",
 								""
 							]
@@ -2844,7 +2675,7 @@
 							"script": {
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
-									"postman.setEnvironmentVariable(\"plan\", jsonData.id);"
+									"postman.setEnvironmentVariable(\"planId\", jsonData.id);"
 								],
 								"type": "text/javascript"
 							}
@@ -2870,7 +2701,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"name\":\"Keyless\",\n    \"description\":\"Keyless\",\n    \"characteristics\":[],\n    \"security\": {\n        \"type\": \"key-less\"\n    },\n    \"mode\": \"STANDARD\"\n}",
+							"raw": "{\n    \"definitionVersion\":\"V4\",\n    \"name\":\"Keyless\",\n    \"description\":\"Keyless\",\n    \"characteristics\":[],\n    \"security\": {\n        \"type\": \"KEY_LESS\"\n    },\n    \"mode\": \"STANDARD\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -2878,19 +2709,17 @@
 							}
 						},
 						"url": {
-							"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans",
+							"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans",
 							"host": [
 								"{{management_host}}"
 							],
 							"path": [
 								"management",
-								"organizations",
-								"DEFAULT",
+								"v2",
 								"environments",
 								"DEFAULT",
-								"v4",
 								"apis",
-								"{{api}}",
+								"{{apiId}}",
 								"plans"
 							]
 						}
@@ -2918,21 +2747,19 @@
 						"method": "POST",
 						"header": [],
 						"url": {
-							"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans/{{plan}}/_publish",
+							"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans/{{planId}}/_publish",
 							"host": [
 								"{{management_host}}"
 							],
 							"path": [
 								"management",
-								"organizations",
-								"DEFAULT",
+								"v2",
 								"environments",
 								"DEFAULT",
-								"v4",
 								"apis",
-								"{{api}}",
+								"{{apiId}}",
 								"plans",
-								"{{plan}}",
+								"{{planId}}",
 								"_publish"
 							]
 						}
@@ -2960,26 +2787,18 @@
 						"method": "POST",
 						"header": [],
 						"url": {
-							"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/?action=start",
+							"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/_start",
 							"host": [
 								"{{management_host}}"
 							],
 							"path": [
 								"management",
-								"organizations",
-								"DEFAULT",
+								"v2",
 								"environments",
 								"DEFAULT",
-								"v4",
 								"apis",
-								"{{api}}",
-								""
-							],
-							"query": [
-								{
-									"key": "action",
-									"value": "start"
-								}
+								"{{apiId}}",
+								"_start"
 							]
 						}
 					},
@@ -3001,7 +2820,7 @@
 									"script": {
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
-											"postman.setEnvironmentVariable(\"api\", jsonData.id);"
+											"postman.setEnvironmentVariable(\"apiId\", jsonData.id);"
 										],
 										"type": "text/javascript"
 									}
@@ -3034,7 +2853,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"name\": \"Event Consumption - Webhook\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"4.0.0\",\n    \"type\": \"message\",\n    \"description\": \"Event Consumption - Webhook\",\n    \"listeners\": [\n        {\n            \"type\": \"subscription\",\n            \"entrypoints\": [\n                {\n                    \"type\": \"webhook\"\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"kafka\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"kafka\",\n                    \"weight\": 1,\n                    \"inheritConfiguration\": false,\n                    \"configuration\": {\n                        \"bootstrapServers\": \"localhost:9092\"\n                    },\n                    \"sharedConfigurationOverride\": {\n                        \"consumer\": {\n                            \"enabled\": true,\n                            \"autoOffsetReset\": \"earliest\",\n                            \"topics\": [\n                                \"demo\"\n                            ]\n                        }\n                    }\n                }\n            ]\n        }\n    ],\n    \"flows\": [\n        {\n            \"name\": \"\",\n            \"selectors\": [],\n            \"request\": [],\n            \"response\": [],\n            \"subscribe\": [],\n            \"publish\": [],\n            \"enabled\": true\n        }\n    ]\n}",
+									"raw": "{\n    \"name\": \"Event Consumption - Webhook\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"V4\",\n    \"type\": \"MESSAGE\",\n    \"description\": \"Event Consumption - Webhook\",\n    \"listeners\": [\n        {\n            \"type\": \"SUBSCRIPTION\",\n            \"entrypoints\": [\n                {\n                    \"type\": \"webhook\"\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"kafka\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"kafka\",\n                    \"weight\": 1,\n                    \"inheritConfiguration\": false,\n                    \"configuration\": {\n                        \"bootstrapServers\": \"localhost:9092\"\n                    },\n                    \"sharedConfigurationOverride\": {\n                        \"consumer\": {\n                            \"enabled\": true,\n                            \"autoOffsetReset\": \"earliest\",\n                            \"topics\": [\n                                \"demo\"\n                            ]\n                        }\n                    }\n                }\n            ]\n        }\n    ],\n    \"flows\": [\n        {\n            \"name\": \"\",\n            \"selectors\": [],\n            \"request\": [],\n            \"response\": [],\n            \"subscribe\": [],\n            \"publish\": [],\n            \"enabled\": true\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -3042,17 +2861,15 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
 										""
 									]
@@ -3068,7 +2885,7 @@
 									"script": {
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
-											"postman.setEnvironmentVariable(\"plan\", jsonData.id);"
+											"postman.setEnvironmentVariable(\"planId\", jsonData.id);"
 										],
 										"type": "text/javascript"
 									}
@@ -3101,7 +2918,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"name\": \"Subscription Plan\",\n    \"description\": \"Subscription Plan\",\n    \"characteristics\": [],\n    \"validation\": \"auto\",\n    \"mode\": \"PUSH\"\n}",
+									"raw": "{\n    \"definitionVersion\":\"V4\",\n    \"name\": \"Subscription Plan\",\n    \"description\": \"Subscription Plan\",\n    \"characteristics\": [],\n    \"validation\": \"AUTO\",\n    \"mode\": \"PUSH\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -3109,19 +2926,17 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"plans"
 									]
 								}
@@ -3165,21 +2980,19 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans/{{plan}}/_publish",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans/{{planId}}/_publish",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"plans",
-										"{{plan}}",
+										"{{planId}}",
 										"_publish"
 									]
 								}
@@ -3205,43 +3018,20 @@
 									]
 								},
 								"method": "POST",
-								"header": [
-									{
-										"key": "Cookie",
-										"value": "Auth-Graviteeio-APIM=Bearer%20eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI2ZjNjZjU2MS1lMTlhLTRlZDItYmNmNS02MWUxOWFhZWQyY2IiLCJwZXJtaXNzaW9ucyI6W3siYXV0aG9yaXR5IjoiRU5WSVJPTk1FTlQ6QURNSU4ifSx7ImF1dGhvcml0eSI6Ik9SR0FOSVpBVElPTjpBRE1JTiJ9LHsiYXV0aG9yaXR5IjoiT1JHQU5JWkFUSU9OOkFETUlOIn0seyJhdXRob3JpdHkiOiJPUkdBTklaQVRJT046VVNFUiJ9LHsiYXV0aG9yaXR5IjoiRU5WSVJPTk1FTlQ6VVNFUiJ9LHsiYXV0aG9yaXR5IjoiRU5WSVJPTk1FTlQ6QURNSU4ifV0sImlzcyI6ImdyYXZpdGVlLW1hbmFnZW1lbnQtYXV0aCIsImV4cCI6MTY1ODc2MTQ2MiwiaWF0IjoxNjU4MTU2NjYyLCJqdGkiOiI4MWQ3NTgzNC0zM2UyLTRkZjctYWYxYy1lZGI4NWI3M2M3MTcifQ.3U_Ma27VwGH7bynfC8wgw4SbsSPQjEp0O93Xp-2XrCA; XSRF-TOKEN=eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJncmF2aXRlZS1tYW5hZ2VtZW50LWF1dGgiLCJpYXQiOjE2NTgxNTY3NjQsInRva2VuIjoiYmFlNjRkNGUtYjczYy00ZmQ3LTk0OTMtOTRkODZlZGIyZGQwIn0.66X2Gcvwrosm0HEJ1rB3IS46ySadc0IjKM29LIq2G3s",
-										"type": "text",
-										"disabled": true
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"id\": \"72719d3b-0f28-4c09-b19d-3b0f286c090f\",\n    \"name\": \"apiv4\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"4.0.0\",\n    \"type\": \"message\",\n    \"description\": \"apiv4\",\n    \"listeners\": [\n        {\n            \"type\": \"http\",\n            \"paths\": [\n                {\n                    \"path\": \"/test-jupiter-v4/\"\n                }\n            ],\n            \"entrypoints\": [\n                {\n                    \"type\": \"sse\"\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"kafka\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"kafka\",\n                    \"weight\": 1,\n                    \"inheritConfig\": false\n                }\n            ]\n        }\n    ],\n    \"visibility\": \"PRIVATE\",\n    \"state\": \"STARTED\"\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
+								"header": [],
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}?action=start",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/_start",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}"
-									],
-									"query": [
-										{
-											"key": "action",
-											"value": "start"
-										}
+										"{{apiId}}",
+										"_start"
 									]
 								}
 							},
@@ -3284,20 +3074,18 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/deploy",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/deployments",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
-										"deploy"
+										"{{apiId}}",
+										"deployments"
 									]
 								}
 							},
@@ -3395,7 +3183,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"configuration\": {\n        \"entrypointId\": \"webhook\",\n        \"entrypointConfiguration\": {\n            \"callbackUrl\": \"https://webhook.site/da30c1c4-5806-479e-aa89-03aab4b28432\",\n            \"headers\": [\n                {\n                    \"name\": \"demoHeader\",\n                    \"value\": \"my-value\"\n                },\n                {\n                    \"name\": \"anotherHeader\",\n                    \"value\": \"my-value2\"\n                }\n            ]\n        }\n    }\n}",
+									"raw": "{\n    \"applicationId\": \"{{application}}\",\n    \"planId\": \"{{planId}}\",\n    \"consumerConfiguration\": {\n        \"entrypointId\": \"webhook\",\n        \"channel\": \"/channel1\",\n        \"entrypointConfiguration\": {\n            \"callbackUrl\": \"https://webhook.site/da30c1c4-5806-479e-aa89-03aab4b28432\",\n            \"headers\": [\n                {\n                    \"name\": \"demoHeader\",\n                    \"value\": \"my-value\"\n                },\n                {\n                    \"name\": \"anotherHeader\",\n                    \"value\": \"my-value2\"\n                }\n            ]\n        }\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -3403,30 +3191,18 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/subscriptions?application={{application}}&plan={{plan}}",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/subscriptions",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"subscriptions"
-									],
-									"query": [
-										{
-											"key": "application",
-											"value": "{{application}}"
-										},
-										{
-											"key": "plan",
-											"value": "{{plan}}"
-										}
 									]
 								}
 							},
@@ -3445,7 +3221,7 @@
 									"script": {
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
-											"postman.setEnvironmentVariable(\"api\", jsonData.id);"
+											"postman.setEnvironmentVariable(\"apiId\", jsonData.id);"
 										],
 										"type": "text/javascript"
 									}
@@ -3478,7 +3254,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"name\": \"Event Consumption - Webhook - Cloud Events\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"4.0.0\",\n    \"type\": \"message\",\n    \"description\": \"Event Consumption - Webhook - Cloud Events\",\n    \"listeners\": [\n        {\n            \"type\": \"subscription\",\n            \"entrypoints\": [\n                {\n                    \"type\": \"webhook\"\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"kafka\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"kafka\",\n                    \"weight\": 1,\n                    \"inheritConfiguration\": false,\n                    \"configuration\": {\n                        \"bootstrapServers\": \"kafka:9092\"\n                    },\n                    \"sharedConfigurationOverride\": {\n                        \"consumer\": {\n                            \"enabled\": true,\n                            \"topics\": [\n                                \"demo\"\n                            ],\n                            \"autoOffsetReset\": \"earliest\"\n                        }\n                    }\n                }\n            ]\n        }\n    ],\n    \"flows\": [\n        {\n            \"name\": \"\",\n            \"selectors\": [],\n            \"request\": [],\n            \"response\": [],\n            \"subscribe\": [\n                {\n                    \"name\": \"Cloud Events\",\n                    \"description\": \"Transform to cloud-events message\",\n                    \"enabled\": true,\n                    \"policy\": \"cloud-events\",\n                    \"configuration\": {\n                        \"type\": \"demo-events\",\n                        \"id\": \"{#message.metadata['key']}\",\n                        \"source\": \"kafka://{#message.metadata['topic']}/{#message.metadata['partition']}/{#message.metadata['offset']}\"\n                    }\n                }\n            ],\n            \"publish\": [],\n            \"enabled\": true\n        }\n    ]\n}",
+									"raw": "{\n    \"name\": \"Event Consumption - Webhook - Cloud Events\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"V4\",\n    \"type\": \"MESSAGE\",\n    \"description\": \"Event Consumption - Webhook - Cloud Events\",\n    \"listeners\": [\n        {\n            \"type\": \"SUBSCRIPTION\",\n            \"entrypoints\": [\n                {\n                    \"type\": \"webhook\"\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"kafka\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"kafka\",\n                    \"weight\": 1,\n                    \"inheritConfiguration\": false,\n                    \"configuration\": {\n                        \"bootstrapServers\": \"kafka:9092\"\n                    },\n                    \"sharedConfigurationOverride\": {\n                        \"consumer\": {\n                            \"enabled\": true,\n                            \"topics\": [\n                                \"demo\"\n                            ],\n                            \"autoOffsetReset\": \"earliest\"\n                        }\n                    }\n                }\n            ]\n        }\n    ],\n    \"flows\": [\n        {\n            \"name\": \"\",\n            \"selectors\": [],\n            \"request\": [],\n            \"response\": [],\n            \"subscribe\": [\n                {\n                    \"name\": \"Cloud Events\",\n                    \"description\": \"Transform to cloud-events message\",\n                    \"enabled\": true,\n                    \"policy\": \"cloud-events\",\n                    \"configuration\": {\n                        \"type\": \"demo-events\",\n                        \"id\": \"{#message.metadata['key']}\",\n                        \"source\": \"kafka://{#message.metadata['topic']}/{#message.metadata['partition']}/{#message.metadata['offset']}\"\n                    }\n                }\n            ],\n            \"publish\": [],\n            \"enabled\": true\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -3486,17 +3262,15 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
 										""
 									]
@@ -3512,7 +3286,7 @@
 									"script": {
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
-											"postman.setEnvironmentVariable(\"plan\", jsonData.id);"
+											"postman.setEnvironmentVariable(\"planId\", jsonData.id);"
 										],
 										"type": "text/javascript"
 									}
@@ -3545,7 +3319,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"name\":\"Subscription Plan\",\n    \"description\":\"Subscription Plan\",\n    \"characteristics\":[],\n    \"mode\": \"PUSH\"\n}",
+									"raw": "{\n    \"definitionVersion\":\"V4\",\n    \"name\":\"Subscription Plan\",\n    \"description\":\"Subscription Plan\",\n    \"characteristics\":[],\n    \"mode\": \"PUSH\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -3553,19 +3327,17 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"plans"
 									]
 								}
@@ -3609,21 +3381,19 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans/{{plan}}/_publish",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans/{{planId}}/_publish",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"plans",
-										"{{plan}}",
+										"{{planId}}",
 										"_publish"
 									]
 								}
@@ -3649,43 +3419,20 @@
 									]
 								},
 								"method": "POST",
-								"header": [
-									{
-										"key": "Cookie",
-										"value": "Auth-Graviteeio-APIM=Bearer%20eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI2ZjNjZjU2MS1lMTlhLTRlZDItYmNmNS02MWUxOWFhZWQyY2IiLCJwZXJtaXNzaW9ucyI6W3siYXV0aG9yaXR5IjoiRU5WSVJPTk1FTlQ6QURNSU4ifSx7ImF1dGhvcml0eSI6Ik9SR0FOSVpBVElPTjpBRE1JTiJ9LHsiYXV0aG9yaXR5IjoiT1JHQU5JWkFUSU9OOkFETUlOIn0seyJhdXRob3JpdHkiOiJPUkdBTklaQVRJT046VVNFUiJ9LHsiYXV0aG9yaXR5IjoiRU5WSVJPTk1FTlQ6VVNFUiJ9LHsiYXV0aG9yaXR5IjoiRU5WSVJPTk1FTlQ6QURNSU4ifV0sImlzcyI6ImdyYXZpdGVlLW1hbmFnZW1lbnQtYXV0aCIsImV4cCI6MTY1ODc2MTQ2MiwiaWF0IjoxNjU4MTU2NjYyLCJqdGkiOiI4MWQ3NTgzNC0zM2UyLTRkZjctYWYxYy1lZGI4NWI3M2M3MTcifQ.3U_Ma27VwGH7bynfC8wgw4SbsSPQjEp0O93Xp-2XrCA; XSRF-TOKEN=eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJncmF2aXRlZS1tYW5hZ2VtZW50LWF1dGgiLCJpYXQiOjE2NTgxNTY3NjQsInRva2VuIjoiYmFlNjRkNGUtYjczYy00ZmQ3LTk0OTMtOTRkODZlZGIyZGQwIn0.66X2Gcvwrosm0HEJ1rB3IS46ySadc0IjKM29LIq2G3s",
-										"type": "text",
-										"disabled": true
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"id\": \"72719d3b-0f28-4c09-b19d-3b0f286c090f\",\n    \"name\": \"apiv4\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"4.0.0\",\n    \"type\": \"message\",\n    \"description\": \"apiv4\",\n    \"listeners\": [\n        {\n            \"type\": \"http\",\n            \"paths\": [\n                {\n                    \"path\": \"/test-jupiter-v4/\"\n                }\n            ],\n            \"entrypoints\": [\n                {\n                    \"type\": \"sse\"\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"kafka\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"kafka\",\n                    \"weight\": 1,\n                    \"inheritConfig\": false\n                }\n            ]\n        }\n    ],\n    \"visibility\": \"PRIVATE\",\n    \"state\": \"STARTED\"\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
+								"header": [],
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}?action=start",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/_start",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}"
-									],
-									"query": [
-										{
-											"key": "action",
-											"value": "start"
-										}
+										"{{apiId}}",
+										"_start"
 									]
 								}
 							},
@@ -3728,20 +3475,18 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/deploy",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/deployments",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
-										"deploy"
+										"{{apiId}}",
+										"deployments"
 									]
 								}
 							},
@@ -3839,7 +3584,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"configuration\": {\n        \"entrypointId\": \"webhook\",\n        \"entrypointConfiguration\": {\n            \"callbackUrl\": \"https://webhook.site/da3d3edc-c2d1-4c3e-a700-ed3e7073f5d5\",\n            \"headers\": [\n                {\n                    \"name\": \"demoHeader\",\n                    \"value\": \"my-value\"\n                },\n                {\n                    \"name\": \"anotherHeader\",\n                    \"value\": \"my-value2\"\n                }\n            ]\n        }\n    }\n}",
+									"raw": "{\n    \"applicationId\": \"{{application}}\",\n    \"planId\": \"{{planId}}\",\n    \"consumerConfiguration\": {\n        \"entrypointId\": \"webhook\",\n        \"channel\": \"/channel1\",\n        \"entrypointConfiguration\": {\n            \"callbackUrl\": \"https://webhook.site/da3d3edc-c2d1-4c3e-a700-ed3e7073f5d5\",\n            \"headers\": [\n                {\n                    \"name\": \"demoHeader\",\n                    \"value\": \"my-value\"\n                },\n                {\n                    \"name\": \"anotherHeader\",\n                    \"value\": \"my-value2\"\n                }\n            ]\n        }\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -3847,30 +3592,18 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/subscriptions?application={{application}}&plan={{plan}}",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/subscriptions",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"subscriptions"
-									],
-									"query": [
-										{
-											"key": "application",
-											"value": "{{application}}"
-										},
-										{
-											"key": "plan",
-											"value": "{{plan}}"
-										}
 									]
 								}
 							},
@@ -3889,7 +3622,7 @@
 									"script": {
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
-											"postman.setEnvironmentVariable(\"api\", jsonData.id);"
+											"postman.setEnvironmentVariable(\"apiId\", jsonData.id);"
 										],
 										"type": "text/javascript"
 									}
@@ -3922,7 +3655,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"name\": \"Event Consumption - Webhook\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"4.0.0\",\n    \"type\": \"message\",\n    \"description\": \"Event Consumption - Webhook\",\n    \"listeners\": [\n        {\n            \"type\": \"subscription\",\n            \"entrypoints\": [\n                {\n                    \"type\": \"webhook\"\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"kafka\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"kafka\",\n                    \"weight\": 1,\n                    \"inheritConfiguration\": false,\n                    \"configuration\": {\n                        \"bootstrapServers\": \"kafka:9092\"\n                    },\n                    \"sharedConfigurationOverride\": {\n                        \"consumer\": {\n                            \"enabled\": true,\n                            \"topics\": [\n                                \"demo\"\n                            ],\n                            \"autoOffsetReset\": \"earliest\"\n                        }\n                    }\n                }\n            ]\n        }\n    ],\n    \"flows\": [\n        {\n            \"name\": \"\",\n            \"selectors\": [],\n            \"request\": [],\n            \"response\": [],\n            \"subscribe\": [],\n            \"publish\": [],\n            \"enabled\": true\n        }\n    ]\n}",
+									"raw": "{\n    \"name\": \"Event Consumption - Webhook\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"V4\",\n    \"type\": \"MESSAGE\",\n    \"description\": \"Event Consumption - Webhook\",\n    \"listeners\": [\n        {\n            \"type\": \"SUBSCRIPTION\",\n            \"entrypoints\": [\n                {\n                    \"type\": \"webhook\"\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"kafka\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"kafka\",\n                    \"weight\": 1,\n                    \"inheritConfiguration\": false,\n                    \"configuration\": {\n                        \"bootstrapServers\": \"kafka:9092\"\n                    },\n                    \"sharedConfigurationOverride\": {\n                        \"consumer\": {\n                            \"enabled\": true,\n                            \"topics\": [\n                                \"demo\"\n                            ],\n                            \"autoOffsetReset\": \"earliest\"\n                        }\n                    }\n                }\n            ]\n        }\n    ],\n    \"flows\": [\n        {\n            \"name\": \"\",\n            \"selectors\": [],\n            \"request\": [],\n            \"response\": [],\n            \"subscribe\": [],\n            \"publish\": [],\n            \"enabled\": true\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -3930,17 +3663,15 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
 										""
 									]
@@ -3956,7 +3687,7 @@
 									"script": {
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
-											"postman.setEnvironmentVariable(\"plan\", jsonData.id);"
+											"postman.setEnvironmentVariable(\"planId\", jsonData.id);"
 										],
 										"type": "text/javascript"
 									}
@@ -3989,7 +3720,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"name\":\"Subscription Plan\",\n    \"description\":\"Subscription Plan\",\n    \"characteristics\":[],\n    \"mode\": \"PUSH\"\n}",
+									"raw": "{\n    \"definitionVersion\":\"V4\",\n    \"name\":\"Subscription Plan\",\n    \"description\":\"Subscription Plan\",\n    \"characteristics\":[],\n    \"mode\": \"PUSH\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -3997,19 +3728,17 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"plans"
 									]
 								}
@@ -4053,21 +3782,19 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans/{{plan}}/_publish",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans/{{planId}}/_publish",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"plans",
-										"{{plan}}",
+										"{{planId}}",
 										"_publish"
 									]
 								}
@@ -4111,25 +3838,18 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}?action=start",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/_start",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}"
-									],
-									"query": [
-										{
-											"key": "action",
-											"value": "start"
-										}
+										"{{apiId}}",
+										"_start"
 									]
 								}
 							},
@@ -4172,20 +3892,18 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/deploy",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/deployments",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
-										"deploy"
+										"{{apiId}}",
+										"deployments"
 									]
 								}
 							},
@@ -4281,7 +3999,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"application\": \"{{application}}\",\n    \"plan\": \"{{plan}}\",\n    \"configuration\": {\n        \"entrypointId\": \"webhook\",\n        \"entrypointConfiguration\": {\n            \"callbackUrl\": \"https://webhook.site/f1c4ce69-a54e-4e3f-8ae0-9bfb4b26d70f\"\n        }\n    }\n}",
+									"raw": "{\n    \"application\": \"{{application}}\",\n    \"plan\": \"{{planId}}\",\n    \"configuration\": {\n        \"entrypointId\": \"webhook\",\n        \"entrypointConfiguration\": {\n            \"callbackUrl\": \"https://webhook.site/f1c4ce69-a54e-4e3f-8ae0-9bfb4b26d70f\"\n        }\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -4337,7 +4055,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"accepted\": true\n}",
+									"raw": "{\n    \"reason\": \"Ok for me\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -4345,22 +4063,20 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/subscriptions/{{subscription}}/_process",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/subscriptions/{{subscription}}/_accept",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"subscriptions",
 										"{{subscription}}",
-										"_process"
+										"_accept"
 									]
 								}
 							},
@@ -4456,7 +4172,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"accepted\": true\n}",
+									"raw": "{\n    \"reason\": \"Ok for me\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -4464,22 +4180,20 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/subscriptions/{{subscription}}/_process",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/subscriptions/{{subscription}}/_accept",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"subscriptions",
 										"{{subscription}}",
-										"_process"
+										"_accept"
 									]
 								}
 							},
@@ -4493,7 +4207,7 @@
 									"script": {
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
-											"postman.setEnvironmentVariable(\"api\", jsonData.id);"
+											"postman.setEnvironmentVariable(\"apiId\", jsonData.id);"
 										],
 										"type": "text/javascript"
 									}
@@ -4526,7 +4240,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"id\": \"{{api}}\",\n    \"name\": \"Event Consumption - Webhook\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"4.0.0\",\n    \"type\": \"message\",\n    \"deployedAt\": 1669384948542,\n    \"createdAt\": 1669384935062,\n    \"updatedAt\": 1669384948542,\n    \"description\": \"Event Consumption - Webhook\",\n    \"listeners\": [\n        {\n            \"type\": \"subscription\",\n            \"entrypoints\": [\n                {\n                    \"type\": \"webhook\",\n                    \"qos\": \"auto\"\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"kafka\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"kafka\",\n                    \"weight\": 1,\n                    \"inheritConfiguration\": false,\n                    \"configuration\": {\n                        \"bootstrapServers\": \"kafka:9092\"\n                    },\n                    \"sharedConfigurationOverride\": {\n                        \"consumer\": {\n                            \"enabled\": true,\n                            \"topics\": [\n                                \"demo\"\n                            ],\n                            \"autoOffsetReset\": \"earliest\"\n                        }\n                    }\n                }\n            ]\n        }\n    ],\n    \"plans\": [],\n    \"flowExecution\": {\n        \"mode\": \"default\"\n    },\n    \"flows\": [\n        {\n            \"name\": \"\",\n            \"enabled\": true,\n            \"selectors\": [],\n            \"request\": [],\n            \"response\": [],\n            \"subscribe\": [],\n            \"publish\": []\n        }\n    ],\n    \"groups\": [],\n    \"visibility\": \"PRIVATE\",\n    \"state\": \"STARTED\",\n    \"primaryOwner\": {\n        \"id\": \"1c8a99f9-dfd5-46b1-8a99-f9dfd5f6b16c\",\n        \"displayName\": \"admin\",\n        \"type\": \"USER\"\n    },\n    \"lifecycleState\": \"CREATED\",\n    \"disableMembershipNotifications\": false\n}",
+									"raw": "{\n    \"id\": \"{{apiId}}\",\n    \"name\": \"Event Consumption - Webhook\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"V4\",\n    \"type\": \"MESSAGE\",\n    \"deployedAt\": 1669384948542,\n    \"createdAt\": 1669384935062,\n    \"updatedAt\": 1669384948542,\n    \"description\": \"Event Consumption - Webhook\",\n    \"listeners\": [\n        {\n            \"type\": \"SUBSCRIPTION\",\n            \"entrypoints\": [\n                {\n                    \"type\": \"webhook\",\n                    \"qos\": \"AUTO\"\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"kafka\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"kafka\",\n                    \"weight\": 1,\n                    \"inheritConfiguration\": false,\n                    \"configuration\": {\n                        \"bootstrapServers\": \"kafka:9092\"\n                    },\n                    \"sharedConfigurationOverride\": {\n                        \"consumer\": {\n                            \"enabled\": true,\n                            \"topics\": [\n                                \"demo\"\n                            ],\n                            \"autoOffsetReset\": \"earliest\"\n                        }\n                    }\n                }\n            ]\n        }\n    ],\n    \"plans\": [],\n    \"flowExecution\": {\n        \"mode\": \"DEFAULT\"\n    },\n    \"flows\": [\n        {\n            \"name\": \"\",\n            \"enabled\": true,\n            \"selectors\": [],\n            \"request\": [],\n            \"response\": [],\n            \"subscribe\": [],\n            \"publish\": []\n        }\n    ],\n    \"groups\": [],\n    \"visibility\": \"PRIVATE\",\n    \"state\": \"STARTED\",\n    \"primaryOwner\": {\n        \"id\": \"1c8a99f9-dfd5-46b1-8a99-f9dfd5f6b16c\",\n        \"displayName\": \"admin\",\n        \"type\": \"USER\"\n    },\n    \"lifecycleState\": \"CREATED\",\n    \"disableMembershipNotifications\": false\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -4534,19 +4248,17 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}"
+										"{{apiId}}"
 									]
 								}
 							},
@@ -4589,20 +4301,18 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/deploy",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/deployments",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
-										"deploy"
+										"{{apiId}}",
+										"deployments"
 									]
 								}
 							},
@@ -4713,28 +4423,20 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/subscriptions/{{subscription}}/status?status=PAUSED",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/subscriptions/{{subscription}}/_pause",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"subscriptions",
 										"{{subscription}}",
-										"status"
-									],
-									"query": [
-										{
-											"key": "status",
-											"value": "PAUSED"
-										}
+										"_pause"
 									]
 								}
 							},
@@ -4845,28 +4547,20 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/subscriptions/{{subscription}}/status?status=RESUMED",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/subscriptions/{{subscription}}/_resume",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"subscriptions",
 										"{{subscription}}",
-										"status"
-									],
-									"query": [
-										{
-											"key": "status",
-											"value": "RESUMED"
-										}
+										"_resume"
 									]
 								}
 							},
@@ -4885,7 +4579,7 @@
 									"script": {
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
-											"postman.setEnvironmentVariable(\"api\", jsonData.id);"
+											"postman.setEnvironmentVariable(\"apiId\", jsonData.id);"
 										],
 										"type": "text/javascript"
 									}
@@ -4918,7 +4612,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"name\": \"Event Consumption - Webhook - Subscription Filtering\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"4.0.0\",\n    \"type\": \"message\",\n    \"description\": \"Event Consumption - Webhook - Subscription Filtering\",\n    \"listeners\": [\n        {\n            \"type\": \"subscription\",\n            \"entrypoints\": [\n                {\n                    \"type\": \"webhook\"\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"kafka\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"kafka\",\n                    \"weight\": 1,\n                    \"inheritConfiguration\": false,\n                    \"configuration\": {\n                        \"bootstrapServers\": \"kafka:9092\"\n                    },\n                    \"sharedConfigurationOverride\": {\n                        \"consumer\": {\n                            \"enabled\": true,\n                            \"topics\": [\n                                \"demo\"\n                            ],\n                            \"autoOffsetReset\": \"earliest\"\n                        }\n                    }\n                }\n            ]\n        }\n    ],\n    \"flows\": [\n        {\n            \"name\": \"\",\n            \"selectors\": [],\n            \"request\": [],\n            \"response\": [],\n            \"subscribe\": [\n                {\n                    \"name\": \"Message filtering\",\n                    \"description\": \"Apply filter to messages\",\n                    \"enabled\": true,\n                    \"policy\": \"message-filtering\",\n                    \"configuration\": {\n                        \"filter\": \"{#jsonPath(#message.content, '$.feature') == #subscription.metadata.feature}\"\n                    }\n                }\n            ],\n            \"publish\": [],\n            \"enabled\": true\n        }\n    ]\n}",
+									"raw": "{\n    \"name\": \"Event Consumption - Webhook - Subscription Filtering\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"V4\",\n    \"type\": \"MESSAGE\",\n    \"description\": \"Event Consumption - Webhook - Subscription Filtering\",\n    \"listeners\": [\n        {\n            \"type\": \"SUBSCRIPTION\",\n            \"entrypoints\": [\n                {\n                    \"type\": \"webhook\"\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"kafka\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"kafka\",\n                    \"weight\": 1,\n                    \"inheritConfiguration\": false,\n                    \"configuration\": {\n                        \"bootstrapServers\": \"kafka:9092\"\n                    },\n                    \"sharedConfigurationOverride\": {\n                        \"consumer\": {\n                            \"enabled\": true,\n                            \"topics\": [\n                                \"demo\"\n                            ],\n                            \"autoOffsetReset\": \"earliest\"\n                        }\n                    }\n                }\n            ]\n        }\n    ],\n    \"flows\": [\n        {\n            \"name\": \"\",\n            \"selectors\": [],\n            \"request\": [],\n            \"response\": [],\n            \"subscribe\": [\n                {\n                    \"name\": \"Message filtering\",\n                    \"description\": \"Apply filter to messages\",\n                    \"enabled\": true,\n                    \"policy\": \"message-filtering\",\n                    \"configuration\": {\n                        \"filter\": \"{#jsonPath(#message.content, '$.feature') == #subscription.metadata.feature}\"\n                    }\n                }\n            ],\n            \"publish\": [],\n            \"enabled\": true\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -4926,17 +4620,15 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
 										""
 									]
@@ -4952,7 +4644,7 @@
 									"script": {
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
-											"postman.setEnvironmentVariable(\"plan\", jsonData.id);"
+											"postman.setEnvironmentVariable(\"planId\", jsonData.id);"
 										],
 										"type": "text/javascript"
 									}
@@ -4985,7 +4677,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"name\":\"Subscription Plan\",\n    \"description\":\"Subscription Plan\",\n    \"characteristics\":[],\n    \"mode\": \"PUSH\"\n}",
+									"raw": "{\n    \"definitionVersion\":\"V4\",\n    \"name\":\"Subscription Plan\",\n    \"description\":\"Subscription Plan\",\n    \"characteristics\":[],\n    \"mode\": \"PUSH\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -4993,19 +4685,17 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"plans"
 									]
 								}
@@ -5049,21 +4739,19 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans/{{plan}}/_publish",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans/{{planId}}/_publish",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"plans",
-										"{{plan}}",
+										"{{planId}}",
 										"_publish"
 									]
 								}
@@ -5089,43 +4777,20 @@
 									]
 								},
 								"method": "POST",
-								"header": [
-									{
-										"key": "Cookie",
-										"value": "Auth-Graviteeio-APIM=Bearer%20eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI2ZjNjZjU2MS1lMTlhLTRlZDItYmNmNS02MWUxOWFhZWQyY2IiLCJwZXJtaXNzaW9ucyI6W3siYXV0aG9yaXR5IjoiRU5WSVJPTk1FTlQ6QURNSU4ifSx7ImF1dGhvcml0eSI6Ik9SR0FOSVpBVElPTjpBRE1JTiJ9LHsiYXV0aG9yaXR5IjoiT1JHQU5JWkFUSU9OOkFETUlOIn0seyJhdXRob3JpdHkiOiJPUkdBTklaQVRJT046VVNFUiJ9LHsiYXV0aG9yaXR5IjoiRU5WSVJPTk1FTlQ6VVNFUiJ9LHsiYXV0aG9yaXR5IjoiRU5WSVJPTk1FTlQ6QURNSU4ifV0sImlzcyI6ImdyYXZpdGVlLW1hbmFnZW1lbnQtYXV0aCIsImV4cCI6MTY1ODc2MTQ2MiwiaWF0IjoxNjU4MTU2NjYyLCJqdGkiOiI4MWQ3NTgzNC0zM2UyLTRkZjctYWYxYy1lZGI4NWI3M2M3MTcifQ.3U_Ma27VwGH7bynfC8wgw4SbsSPQjEp0O93Xp-2XrCA; XSRF-TOKEN=eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJncmF2aXRlZS1tYW5hZ2VtZW50LWF1dGgiLCJpYXQiOjE2NTgxNTY3NjQsInRva2VuIjoiYmFlNjRkNGUtYjczYy00ZmQ3LTk0OTMtOTRkODZlZGIyZGQwIn0.66X2Gcvwrosm0HEJ1rB3IS46ySadc0IjKM29LIq2G3s",
-										"type": "text",
-										"disabled": true
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"id\": \"72719d3b-0f28-4c09-b19d-3b0f286c090f\",\n    \"name\": \"apiv4\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"4.0.0\",\n    \"type\": \"message\",\n    \"description\": \"apiv4\",\n    \"listeners\": [\n        {\n            \"type\": \"http\",\n            \"paths\": [\n                {\n                    \"path\": \"/test-jupiter-v4/\"\n                }\n            ],\n            \"entrypoints\": [\n                {\n                    \"type\": \"sse\"\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"kafka\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"kafka\",\n                    \"weight\": 1,\n                    \"inheritConfig\": false\n                }\n            ]\n        }\n    ],\n    \"visibility\": \"PRIVATE\",\n    \"state\": \"STARTED\"\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
+								"header": [],
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}?action=start",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/_start",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}"
-									],
-									"query": [
-										{
-											"key": "action",
-											"value": "start"
-										}
+										"{{apiId}}",
+										"_start"
 									]
 								}
 							},
@@ -5168,20 +4833,18 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/deploy",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/deployments",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
-										"deploy"
+										"{{apiId}}",
+										"deployments"
 									]
 								}
 							},
@@ -5279,7 +4942,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"configuration\": {\n        \"entrypointId\": \"webhook\",\n        \"entrypointConfiguration\": {\n            \"callbackUrl\": \"https://webhook.site/b27b358b-1fcc-4fd3-87b4-3dce109563a7\",\n            \"headers\": [\n                {\n                    \"name\": \"demoHeader\",\n                    \"value\": \"my-value\"\n                },\n                {\n                    \"name\": \"anotherHeader\",\n                    \"value\": \"my-value2\"\n                }\n            ]\n        }\n    },\n    \"metadata\": {\n        \"feature\": \"demo\"\n    }\n}",
+									"raw": "{\n    \"applicationId\": \"{{application}}\",\n    \"planId\": \"{{planId}}\",\n    \"consumerConfiguration\": {\n        \"entrypointId\": \"webhook\",\n        \"channel\": \"/channel1\",\n        \"entrypointConfiguration\": {\n            \"callbackUrl\": \"https://webhook.site/da3d3edc-c2d1-4c3e-a700-ed3e7073f5d5\",\n            \"headers\": [\n                {\n                    \"name\": \"demoHeader\",\n                    \"value\": \"my-value\"\n                },\n                {\n                    \"name\": \"anotherHeader\",\n                    \"value\": \"my-value2\"\n                }\n            ]\n        }\n    },\n    \"metadata\": {\n        \"feature\": \"demo\"\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -5287,30 +4950,18 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/subscriptions?application={{application}}&plan={{plan}}",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/subscriptions",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"subscriptions"
-									],
-									"query": [
-										{
-											"key": "application",
-											"value": "{{application}}"
-										},
-										{
-											"key": "plan",
-											"value": "{{plan}}"
-										}
 									]
 								}
 							},
@@ -5408,7 +5059,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"configuration\": {\n        \"entrypointId\": \"webhook\",\n        \"entrypointConfiguration\": {\n            \"callbackUrl\": \"https://webhook.site/b27b358b-1fcc-4fd3-87b4-3dce109563a7\",\n            \"headers\": [\n                {\n                    \"name\": \"demoHeader\",\n                    \"value\": \"my-value\"\n                },\n                {\n                    \"name\": \"anotherHeader\",\n                    \"value\": \"my-value2\"\n                }\n            ]\n        }\n    },\n    \"metadata\": {\n        \"feature\": \"demo2\"\n    }\n}",
+									"raw": "{\n    \"applicationId\": \"{{application}}\",\n    \"planId\": \"{{planId}}\",\n    \"consumerConfiguration\": {\n        \"entrypointId\": \"webhook\",\n        \"channel\": \"/channe1\",\n        \"entrypointConfiguration\": {\n            \"callbackUrl\": \"https://webhook.site/b27b358b-1fcc-4fd3-87b4-3dce109563a7\",\n            \"headers\": [\n                {\n                    \"name\": \"demoHeader\",\n                    \"value\": \"my-value\"\n                },\n                {\n                    \"name\": \"anotherHeader\",\n                    \"value\": \"my-value2\"\n                }\n            ]\n        }\n    },\n    \"metadata\": {\n        \"feature\": \"demo2\"\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -5416,30 +5067,18 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/subscriptions?application={{application}}&plan={{plan}}",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/subscriptions",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"subscriptions"
-									],
-									"query": [
-										{
-											"key": "application",
-											"value": "{{application}}"
-										},
-										{
-											"key": "plan",
-											"value": "{{plan}}"
-										}
 									]
 								}
 							},
@@ -5460,7 +5099,7 @@
 							"script": {
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
-									"postman.setEnvironmentVariable(\"api\", jsonData.id);"
+									"postman.setEnvironmentVariable(\"apiId\", jsonData.id);"
 								],
 								"type": "text/javascript"
 							}
@@ -5493,7 +5132,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"name\": \"Event Consumption - HTTP - GET\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"4.0.0\",\n    \"type\": \"message\",\n    \"description\": \"Event Consumption - HTTP - GET\",\n    \"listeners\": [\n        {\n            \"type\": \"http\",\n            \"paths\": [\n                {\n                    \"path\": \"/demo/http-get\"\n                }\n            ],\n            \"entrypoints\": [\n                {\n                    \"type\": \"http-get\",\n                    \"configuration\": {\n                        \"messagesLimitCount\": 500,\n                        \"messagesLimitDurationMs\": 5000,\n                        \"headersInPayload\": false,\n                        \"metadataInPayload\": false\n                    }\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"kafka\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"kafka\",\n                    \"weight\": 1,\n                    \"inheritConfiguration\": false,\n                    \"configuration\": {\n                        \"bootstrapServers\": \"kafka:9092\"\n                    },\n                    \"sharedConfigurationOverride\": {\n                        \"consumer\": {\n                            \"enabled\": true,\n                            \"topics\": [\n                                \"demo\"\n                            ],\n                            \"autoOffsetReset\": \"earliest\"\n                        }\n                    }\n                }\n            ]\n        }\n    ]\n}",
+							"raw": "{\n    \"name\": \"Event Consumption - HTTP - GET\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"V4\",\n    \"type\": \"MESSAGE\",\n    \"description\": \"Event Consumption - HTTP - GET\",\n    \"listeners\": [\n        {\n            \"type\": \"HTTP\",\n            \"paths\": [\n                {\n                    \"path\": \"/demo/http-get\"\n                }\n            ],\n            \"entrypoints\": [\n                {\n                    \"type\": \"http-get\",\n                    \"configuration\": {\n                        \"messagesLimitCount\": 500,\n                        \"messagesLimitDurationMs\": 5000,\n                        \"headersInPayload\": false,\n                        \"metadataInPayload\": false\n                    }\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"kafka\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"kafka\",\n                    \"weight\": 1,\n                    \"inheritConfiguration\": false,\n                    \"configuration\": {\n                        \"bootstrapServers\": \"kafka:9092\"\n                    },\n                    \"sharedConfigurationOverride\": {\n                        \"consumer\": {\n                            \"enabled\": true,\n                            \"topics\": [\n                                \"demo\"\n                            ],\n                            \"autoOffsetReset\": \"earliest\"\n                        }\n                    }\n                }\n            ]\n        }\n    ]\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -5501,17 +5140,15 @@
 							}
 						},
 						"url": {
-							"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/",
+							"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/",
 							"host": [
 								"{{management_host}}"
 							],
 							"path": [
 								"management",
-								"organizations",
-								"DEFAULT",
+								"v2",
 								"environments",
 								"DEFAULT",
-								"v4",
 								"apis",
 								""
 							]
@@ -5527,7 +5164,7 @@
 							"script": {
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
-									"postman.setEnvironmentVariable(\"plan\", jsonData.id);"
+									"postman.setEnvironmentVariable(\"planId\", jsonData.id);"
 								],
 								"type": "text/javascript"
 							}
@@ -5553,7 +5190,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"name\":\"Keyless\",\n    \"description\":\"Keyless\",\n    \"characteristics\":[],\n    \"security\": {\n        \"type\": \"key-less\"\n    },\n    \"mode\": \"STANDARD\"\n}",
+							"raw": "{\n    \"definitionVersion\":\"V4\",\n    \"name\":\"Keyless\",\n    \"description\":\"Keyless\",\n    \"characteristics\":[],\n    \"security\": {\n        \"type\": \"KEY_LESS\"\n    },\n    \"mode\": \"STANDARD\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -5561,19 +5198,17 @@
 							}
 						},
 						"url": {
-							"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans",
+							"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans",
 							"host": [
 								"{{management_host}}"
 							],
 							"path": [
 								"management",
-								"organizations",
-								"DEFAULT",
+								"v2",
 								"environments",
 								"DEFAULT",
-								"v4",
 								"apis",
-								"{{api}}",
+								"{{apiId}}",
 								"plans"
 							]
 						}
@@ -5601,21 +5236,19 @@
 						"method": "POST",
 						"header": [],
 						"url": {
-							"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans/{{plan}}/_publish",
+							"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans/{{planId}}/_publish",
 							"host": [
 								"{{management_host}}"
 							],
 							"path": [
 								"management",
-								"organizations",
-								"DEFAULT",
+								"v2",
 								"environments",
 								"DEFAULT",
-								"v4",
 								"apis",
-								"{{api}}",
+								"{{apiId}}",
 								"plans",
-								"{{plan}}",
+								"{{planId}}",
 								"_publish"
 							]
 						}
@@ -5643,26 +5276,18 @@
 						"method": "POST",
 						"header": [],
 						"url": {
-							"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/?action=start",
+							"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/_start",
 							"host": [
 								"{{management_host}}"
 							],
 							"path": [
 								"management",
-								"organizations",
-								"DEFAULT",
+								"v2",
 								"environments",
 								"DEFAULT",
-								"v4",
 								"apis",
-								"{{api}}",
-								""
-							],
-							"query": [
-								{
-									"key": "action",
-									"value": "start"
-								}
+								"{{apiId}}",
+								"_start"
 							]
 						}
 					},
@@ -5681,7 +5306,7 @@
 							"script": {
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
-									"postman.setEnvironmentVariable(\"api\", jsonData.id);"
+									"postman.setEnvironmentVariable(\"apiId\", jsonData.id);"
 								],
 								"type": "text/javascript"
 							}
@@ -5714,7 +5339,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"name\": \"Event Consumption - HTTP - GET\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"4.0.0\",\n    \"type\": \"proxy\",\n    \"description\": \"Event Consumption - HTTP - Proxy\",\n    \"listeners\": [\n        {\n            \"type\": \"http\",\n            \"paths\": [\n                {\n                    \"path\": \"/demo/http-proxy\"\n                }\n            ],\n            \"entrypoints\": [\n                {\n                    \"type\": \"http-proxy\"\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"http-proxy\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"http-proxy\",\n                    \"weight\": 1,\n                    \"inheritConfiguration\": false,\n                    \"configuration\": {\n                        \"target\": \"https://api.gravitee.io/echo\"\n                    }\n                }\n            ]\n        }\n    ]\n}",
+							"raw": "{\n    \"name\": \"Event Consumption - HTTP - GET\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"V4\",\n    \"type\": \"PROXY\",\n    \"description\": \"Event Consumption - HTTP - Proxy\",\n    \"listeners\": [\n        {\n            \"type\": \"HTTP\",\n            \"paths\": [\n                {\n                    \"path\": \"/demo/http-proxy\"\n                }\n            ],\n            \"entrypoints\": [\n                {\n                    \"type\": \"http-proxy\"\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"http-proxy\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"http-proxy\",\n                    \"weight\": 1,\n                    \"inheritConfiguration\": false,\n                    \"configuration\": {\n                        \"target\": \"https://api.gravitee.io/echo\"\n                    }\n                }\n            ]\n        }\n    ]\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -5722,17 +5347,15 @@
 							}
 						},
 						"url": {
-							"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/",
+							"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/",
 							"host": [
 								"{{management_host}}"
 							],
 							"path": [
 								"management",
-								"organizations",
-								"DEFAULT",
+								"v2",
 								"environments",
 								"DEFAULT",
-								"v4",
 								"apis",
 								""
 							]
@@ -5748,7 +5371,7 @@
 							"script": {
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
-									"postman.setEnvironmentVariable(\"plan\", jsonData.id);"
+									"postman.setEnvironmentVariable(\"planId\", jsonData.id);"
 								],
 								"type": "text/javascript"
 							}
@@ -5774,7 +5397,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"name\":\"Keyless\",\n    \"description\":\"Keyless\",\n    \"characteristics\":[],\n    \"security\": {\n        \"type\": \"key-less\"\n    },\n    \"mode\": \"STANDARD\"\n}",
+							"raw": "{\n    \"definitionVersion\":\"V4\",\n    \"name\":\"Keyless\",\n    \"description\":\"Keyless\",\n    \"characteristics\":[],\n    \"security\": {\n        \"type\": \"KEY_LESS\"\n    },\n    \"mode\": \"STANDARD\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -5782,19 +5405,17 @@
 							}
 						},
 						"url": {
-							"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans",
+							"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans",
 							"host": [
 								"{{management_host}}"
 							],
 							"path": [
 								"management",
-								"organizations",
-								"DEFAULT",
+								"v2",
 								"environments",
 								"DEFAULT",
-								"v4",
 								"apis",
-								"{{api}}",
+								"{{apiId}}",
 								"plans"
 							]
 						}
@@ -5822,21 +5443,19 @@
 						"method": "POST",
 						"header": [],
 						"url": {
-							"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans/{{plan}}/_publish",
+							"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans/{{planId}}/_publish",
 							"host": [
 								"{{management_host}}"
 							],
 							"path": [
 								"management",
-								"organizations",
-								"DEFAULT",
+								"v2",
 								"environments",
 								"DEFAULT",
-								"v4",
 								"apis",
-								"{{api}}",
+								"{{apiId}}",
 								"plans",
-								"{{plan}}",
+								"{{planId}}",
 								"_publish"
 							]
 						}
@@ -5864,26 +5483,18 @@
 						"method": "POST",
 						"header": [],
 						"url": {
-							"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/?action=start",
+							"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/_start",
 							"host": [
 								"{{management_host}}"
 							],
 							"path": [
 								"management",
-								"organizations",
-								"DEFAULT",
+								"v2",
 								"environments",
 								"DEFAULT",
-								"v4",
 								"apis",
-								"{{api}}",
-								""
-							],
-							"query": [
-								{
-									"key": "action",
-									"value": "start"
-								}
+								"{{apiId}}",
+								"_start"
 							]
 						}
 					},
@@ -5905,7 +5516,7 @@
 									"script": {
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
-											"postman.setEnvironmentVariable(\"api\", jsonData.id);",
+											"postman.setEnvironmentVariable(\"apiId\", jsonData.id);",
 											"pm.collectionVariables.set(\"apiEntity\", jsonData)"
 										],
 										"type": "text/javascript"
@@ -5932,7 +5543,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"id\": \"log-v4-sync\",\n    \"name\": \"log-v4-sync\",\n    \"description\": \"log-v4-sync\",\n    \"apiVersion\": \"1.0.0\",\n    \"definitionVersion\": \"4.0.0\",\n    \"type\": \"proxy\",\n    \"listeners\": [\n        {\n            \"type\": \"http\",\n            \"paths\": [\n                {\n                    \"path\": \"/demo/analytics/http-proxy\"\n                }\n            ],\n            \"entrypoints\": [\n                {\n                    \"type\": \"http-proxy\"\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"http-proxy\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"http-proxy\",\n                    \"configuration\": {\n                        \"target\": \"https://api.gravitee.io/echo\"\n                    }\n                }\n            ]\n        }\n    ],\n    \"analytics\": {\n        \"enabled\" : true,\n        \"logging\": {\n            \"mode\": {\n                \"entrypoint\": true,\n                \"endpoint\": true\n            },\n            \"phase\": {\n                \"request\": true,\n                \"response\": true\n            },\n            \"content\": {\n                \"headers\": true,\n                \"payload\": true\n            },\n            \"condition\": null\n        }\n    }\n}",
+									"raw": "{\n    \"id\": \"log-v4-sync\",\n    \"name\": \"log-v4-sync\",\n    \"description\": \"log-v4-sync\",\n    \"apiVersion\": \"1.0.0\",\n    \"definitionVersion\": \"V4\",\n    \"type\": \"PROXY\",\n    \"listeners\": [\n        {\n            \"type\": \"HTTP\",\n            \"paths\": [\n                {\n                    \"path\": \"/demo/analytics/http-proxy\"\n                }\n            ],\n            \"entrypoints\": [\n                {\n                    \"type\": \"http-proxy\"\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"http-proxy\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"http-proxy\",\n                    \"configuration\": {\n                        \"target\": \"https://api.gravitee.io/echo\"\n                    }\n                }\n            ]\n        }\n    ],\n    \"analytics\": {\n        \"enabled\" : true,\n        \"logging\": {\n            \"mode\": {\n                \"entrypoint\": true,\n                \"endpoint\": true\n            },\n            \"phase\": {\n                \"request\": true,\n                \"response\": true\n            },\n            \"content\": {\n                \"headers\": true,\n                \"payload\": true\n            },\n            \"condition\": null\n        }\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -5940,17 +5551,15 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
 										""
 									]
@@ -5966,7 +5575,7 @@
 									"script": {
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
-											"postman.setEnvironmentVariable(\"plan\", jsonData.id);"
+											"postman.setEnvironmentVariable(\"planId\", jsonData.id);"
 										],
 										"type": "text/javascript"
 									}
@@ -5992,7 +5601,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"name\":\"Keyless\",\n    \"description\":\"Keyless\",\n    \"characteristics\":[],\n    \"security\": {\n        \"type\": \"key-less\"\n    },\n    \"mode\": \"STANDARD\"\n}",
+									"raw": "{\n    \"definitionVersion\":\"V4\",\n    \"name\":\"Keyless\",\n    \"description\":\"Keyless\",\n    \"characteristics\":[],\n    \"security\": {\n        \"type\": \"KEY_LESS\"\n    },\n    \"mode\": \"STANDARD\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -6000,19 +5609,17 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"plans"
 									]
 								}
@@ -6051,21 +5658,19 @@
 								"method": "POST",
 								"header": [],
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans/{{plan}}/_publish",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans/{{planId}}/_publish",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"plans",
-										"{{plan}}",
+										"{{planId}}",
 										"_publish"
 									]
 								}
@@ -6113,26 +5718,18 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/?action=start",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/_start",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
-										""
-									],
-									"query": [
-										{
-											"key": "action",
-											"value": "start"
-										}
+										"{{apiId}}",
+										"_start"
 									]
 								}
 							},
@@ -6170,7 +5767,7 @@
 									"script": {
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
-											"postman.setEnvironmentVariable(\"api\", jsonData.id);"
+											"postman.setEnvironmentVariable(\"apiId\", jsonData.id);"
 										],
 										"type": "text/javascript"
 									}
@@ -6203,7 +5800,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"name\": \"Event Consumption - SSE\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"4.0.0\",\n    \"type\": \"message\",\n    \"description\": \"Event Consumption - SSE\",\n    \"listeners\": [\n        {\n            \"type\": \"http\",\n            \"paths\": [\n                {\n                    \"path\": \"/demo/analytics/sse/kafka\"\n                }\n            ],\n            \"entrypoints\": [\n                {\n                    \"type\": \"sse\",\n                    \"configuration\": {\n                        \"heartbeatIntervalInMs\": 5000,\n                        \"metadataAsComment\": false,\n                        \"headersAsComment\": false\n                    }\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"kafka\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"kafka\",\n                    \"weight\": 1,\n                    \"inheritConfiguration\": false,\n                    \"configuration\": {\n                        \"bootstrapServers\": \"kafka:9092\"\n                    },\n                    \"sharedConfigurationOverride\": {\n                        \"consumer\": {\n                            \"enabled\": true,\n                            \"topics\": [\n                                \"demo\"\n                            ],\n                            \"autoOffsetReset\": \"earliest\"\n                        }\n                    }\n                }\n            ]\n        }\n    ],\n    \"analytics\": {\n        \"enabled\": true,\n        \"messageSampling\": {\n            \"type\": \"count\",\n            \"value\": \"10\"\n        },\n        \"logging\": {\n            \"mode\": {\n                \"entrypoint\": true,\n                \"endpoint\": true\n            },\n            \"phase\": {\n                \"request\": true,\n                \"response\": true\n            },\n            \"content\": {\n                \"headers\": true,\n                \"messageHeaders\": true,\n                \"messageMetadata\": true,\n                \"messagePayload\": true\n            },\n            \"condition\": null,\n            \"messageCondition\": null\n        }\n    }\n}",
+									"raw": "{\n    \"name\": \"Event Consumption - SSE\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"V4\",\n    \"type\": \"MESSAGE\",\n    \"description\": \"Event Consumption - SSE\",\n    \"listeners\": [\n        {\n            \"type\": \"HTTP\",\n            \"paths\": [\n                {\n                    \"path\": \"/demo/analytics/sse/kafka\"\n                }\n            ],\n            \"entrypoints\": [\n                {\n                    \"type\": \"sse\",\n                    \"configuration\": {\n                        \"heartbeatIntervalInMs\": 5000,\n                        \"metadataAsComment\": false,\n                        \"headersAsComment\": false\n                    }\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"kafka\",\n            \"endpoints\": [\n                {\n                    \"name\": \"default\",\n                    \"type\": \"kafka\",\n                    \"weight\": 1,\n                    \"inheritConfiguration\": false,\n                    \"configuration\": {\n                        \"bootstrapServers\": \"kafka:9092\"\n                    },\n                    \"sharedConfigurationOverride\": {\n                        \"consumer\": {\n                            \"enabled\": true,\n                            \"topics\": [\n                                \"demo\"\n                            ],\n                            \"autoOffsetReset\": \"earliest\"\n                        }\n                    }\n                }\n            ]\n        }\n    ],\n    \"analytics\": {\n        \"enabled\": true,\n        \"messageSampling\": {\n            \"type\": \"COUNT\",\n            \"value\": \"10\"\n        },\n        \"logging\": {\n            \"mode\": {\n                \"entrypoint\": true,\n                \"endpoint\": true\n            },\n            \"phase\": {\n                \"request\": true,\n                \"response\": true\n            },\n            \"content\": {\n                \"headers\": true,\n                \"messageHeaders\": true,\n                \"messageMetadata\": true,\n                \"messagePayload\": true\n            },\n            \"condition\": null,\n            \"messageCondition\": null\n        }\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -6211,17 +5808,15 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
 										""
 									]
@@ -6237,7 +5832,7 @@
 									"script": {
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
-											"postman.setEnvironmentVariable(\"plan\", jsonData.id);"
+											"postman.setEnvironmentVariable(\"planId\", jsonData.id);"
 										],
 										"type": "text/javascript"
 									}
@@ -6263,7 +5858,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"name\":\"Keyless\",\n    \"description\":\"Keyless\",\n    \"characteristics\":[],\n    \"security\": {\n        \"type\": \"key-less\"\n    },\n    \"mode\": \"STANDARD\"\n}",
+									"raw": "{\n    \"definitionVersion\":\"V4\",\n    \"name\":\"Keyless\",\n    \"description\":\"Keyless\",\n    \"characteristics\":[],\n    \"security\": {\n        \"type\": \"KEY_LESS\"\n    },\n    \"mode\": \"STANDARD\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -6271,19 +5866,17 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"plans"
 									]
 								}
@@ -6311,21 +5904,19 @@
 								"method": "POST",
 								"header": [],
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans/{{plan}}/_publish",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans/{{planId}}/_publish",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"plans",
-										"{{plan}}",
+										"{{planId}}",
 										"_publish"
 									]
 								}
@@ -6353,26 +5944,18 @@
 								"method": "POST",
 								"header": [],
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/?action=start",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/_start",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
-										""
-									],
-									"query": [
-										{
-											"key": "action",
-											"value": "start"
-										}
+										"{{apiId}}",
+										"_start"
 									]
 								}
 							},
@@ -6396,7 +5979,7 @@
 									"script": {
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
-											"postman.setEnvironmentVariable(\"api\", jsonData.id);",
+											"postman.setEnvironmentVariable(\"apiId\", jsonData.id);",
 											"pm.collectionVariables.set(\"apiEntity\", jsonData)"
 										],
 										"type": "text/javascript"
@@ -6423,7 +6006,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"name\": \"demo-proxy-service-discovery\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"4.0.0\",\n    \"type\": \"proxy\",\n    \"description\": \"demo-proxy-service-discovery\",\n    \"listeners\": [\n        {\n            \"type\": \"http\",\n            \"paths\": [\n                {\n                    \"path\": \"/demo/service-discovery/http-proxy\"\n                }\n            ],\n            \"entrypoints\": [\n                {\n                    \"type\": \"http-proxy\"\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"http-proxy\",\n            \"services\": {\n                \"discovery\": {\n                    \"enabled\": true,\n                    \"type\": \"consul-service-discovery\",\n                    \"configuration\": {\"url\": \"http://consul-server:8500\", \"service\": \"whattimeisit\"}\n                }\n            },\n            \"endpoints\": []\n        }\n    ],\n    \"flows\": []\n}",
+									"raw": "{\n    \"name\": \"demo-proxy-service-discovery\",\n    \"apiVersion\": \"1.0\",\n    \"definitionVersion\": \"V4\",\n    \"type\": \"PROXY\",\n    \"description\": \"demo-proxy-service-discovery\",\n    \"listeners\": [\n        {\n            \"type\": \"HTTP\",\n            \"paths\": [\n                {\n                    \"path\": \"/demo/service-discovery/http-proxy\"\n                }\n            ],\n            \"entrypoints\": [\n                {\n                    \"type\": \"http-proxy\"\n                }\n            ]\n        }\n    ],\n    \"endpointGroups\": [\n        {\n            \"name\": \"default-group\",\n            \"type\": \"http-proxy\",\n            \"services\": {\n                \"discovery\": {\n                    \"enabled\": true,\n                    \"type\": \"consul-service-discovery\",\n                    \"configuration\": {\"url\": \"http://consul-server:8500\", \"service\": \"whattimeisit\"}\n                }\n            },\n            \"endpoints\": []\n        }\n    ],\n    \"flows\": []\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -6431,17 +6014,15 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
 										""
 									]
@@ -6457,7 +6038,7 @@
 									"script": {
 										"exec": [
 											"var jsonData = JSON.parse(responseBody);",
-											"postman.setEnvironmentVariable(\"plan\", jsonData.id);"
+											"postman.setEnvironmentVariable(\"planId\", jsonData.id);"
 										],
 										"type": "text/javascript"
 									}
@@ -6483,7 +6064,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"name\":\"Keyless\",\n    \"description\":\"Keyless\",\n    \"characteristics\":[],\n    \"security\": {\n        \"type\": \"key-less\"\n    },\n    \"mode\": \"STANDARD\"\n}",
+									"raw": "{\n    \"definitionVersion\":\"V4\",\n    \"name\":\"Keyless\",\n    \"description\":\"Keyless\",\n    \"characteristics\":[],\n    \"security\": {\n        \"type\": \"KEY_LESS\"\n    },\n    \"mode\": \"STANDARD\"\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -6491,19 +6072,17 @@
 									}
 								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"plans"
 									]
 								}
@@ -6542,21 +6121,19 @@
 								"method": "POST",
 								"header": [],
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/plans/{{plan}}/_publish",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/plans/{{planId}}/_publish",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
+										"{{apiId}}",
 										"plans",
-										"{{plan}}",
+										"{{planId}}",
 										"_publish"
 									]
 								}
@@ -6594,36 +6171,19 @@
 								},
 								"method": "POST",
 								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"deploymentLabel\": \"\"\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
 								"url": {
-									"raw": "{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/v4/apis/{{api}}/?action=start",
+									"raw": "{{management_host}}/management/v2/environments/DEFAULT/apis/{{apiId}}/_start",
 									"host": [
 										"{{management_host}}"
 									],
 									"path": [
 										"management",
-										"organizations",
-										"DEFAULT",
+										"v2",
 										"environments",
 										"DEFAULT",
-										"v4",
 										"apis",
-										"{{api}}",
-										""
-									],
-									"query": [
-										{
-											"key": "action",
-											"value": "start"
-										}
+										"{{apiId}}",
+										"_start"
 									]
 								}
 							},


### PR DESCRIPTION
This PR modifies "policies" and "V4 API Management" collections to use the new Management API v2.

URLs and payloads have been updated.